### PR TITLE
refactor: production-grade error types, async pipeline, SRP decomposition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 !TOOLS.md
 .docs/
 .plan/
+.claude

--- a/README.md
+++ b/README.md
@@ -30,11 +30,71 @@ An MCP server for semantic code search in Rust codebases. Combines BM25 full-tex
 | `index_codebase` | Manually trigger indexing |
 | `health_check` | Check system status |
 
-## Building
+## Installation
+
+### 1. Build the binary
 
 ```bash
+git clone https://github.com/molaco/rust-code-mcp.git
+cd rust-code-mcp
 cargo build --release
 ```
+
+The binary is at `target/release/file-search-mcp`.
+
+Optionally, copy it somewhere on your PATH:
+
+```bash
+cp target/release/file-search-mcp ~/.local/bin/
+```
+
+### 2. Add to Claude Code
+
+In your Rust project directory, create `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "rust-code-mcp": {
+      "command": "/absolute/path/to/file-search-mcp"
+    }
+  }
+}
+```
+
+Or add it globally in `~/.claude.json` so it's available in all projects:
+
+```json
+{
+  "mcpServers": {
+    "rust-code-mcp": {
+      "command": "/absolute/path/to/file-search-mcp"
+    }
+  }
+}
+```
+
+### 3. Index your codebase
+
+Once Claude Code starts, the server is running. Use the `index_codebase` tool to index your project:
+
+```
+> index my codebase at /absolute/path/to/my-rust-project
+```
+
+Or call the tool directly with the `directory` parameter set to your project root. Indexing is incremental — subsequent runs only process changed files (via Merkle tree change detection). A background sync also re-indexes every 5 minutes automatically.
+
+### 4. Start using it
+
+All tools accept a `directory` parameter pointing to your project root. Examples:
+
+- **Search code**: `search` with a query like "error handling in parser"
+- **Find definitions**: `find_definition` for a symbol name
+- **Find references**: `find_references` to see all usages of a symbol
+- **Call graph**: `get_call_graph` to trace function relationships
+- **Similar code**: `get_similar_code` for semantic similarity search
+
+Index data is stored in `~/Library/Application Support/dev.rust-code-mcp.search/` (macOS) or `~/.local/share/search/` (Linux), keyed by a hash of the project path — it never writes to your project directory.
 
 ## Nix
 
@@ -49,20 +109,6 @@ nix build github:molaco/rust-code-mcp
 ```
 
 The dev shell includes nightly Rust and CUDA support.
-
-## Configuration
-
-The server uses stdio transport. Add to your MCP client config:
-
-```json
-{
-  "mcpServers": {
-    "rust-code-mcp": {
-      "command": "/path/to/file-search-mcp"
-    }
-  }
-}
-```
 
 ## GPU Acceleration
 

--- a/examples/index_codebase.rs
+++ b/examples/index_codebase.rs
@@ -24,7 +24,6 @@ async fn main() {
     let mut indexer = IncrementalIndexer::new(
         &cache,
         &tantivy,
-        "http://localhost:6333",
         &format!("rust_code_bench_{}", uuid::Uuid::new_v4()),
         384,
         None,

--- a/examples/index_codebase.rs
+++ b/examples/index_codebase.rs
@@ -1,5 +1,6 @@
 //! Index rust-code-mcp codebase with GPU
 
+use file_search_mcp::embeddings::EMBEDDING_DIM;
 use file_search_mcp::indexing::IncrementalIndexer;
 use std::path::PathBuf;
 use std::time::Instant;
@@ -25,7 +26,7 @@ async fn main() {
         &cache,
         &tantivy,
         &format!("rust_code_bench_{}", uuid::Uuid::new_v4()),
-        384,
+        EMBEDDING_DIM,
         None,
     )
     .await

--- a/examples/quick_bench.rs
+++ b/examples/quick_bench.rs
@@ -1,5 +1,6 @@
 //! Quick GPU benchmark - run with: cargo run --release --bin quick_bench
 
+use file_search_mcp::embeddings::EMBEDDING_DIM;
 use file_search_mcp::indexing::IncrementalIndexer;
 use std::path::PathBuf;
 use std::time::Instant;
@@ -29,7 +30,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         &cache_path,
         &tantivy_path,
         &collection_name,
-        384,
+        EMBEDDING_DIM,
         None,
     )
     .await?;

--- a/examples/quick_bench.rs
+++ b/examples/quick_bench.rs
@@ -28,7 +28,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut indexer = IncrementalIndexer::new(
         &cache_path,
         &tantivy_path,
-        "http://localhost:6333",
         &collection_name,
         384,
         None,

--- a/src/chunker/mod.rs
+++ b/src/chunker/mod.rs
@@ -3,7 +3,7 @@
 //! Chunks code by symbols (functions, structs, etc.) and adds rich context
 //! for better embedding and retrieval quality.
 
-use crate::parser::{CallGraph, Import, ParseResult, Symbol, SymbolKind};
+use crate::parser::{ParseResult, Symbol};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use uuid::Uuid;

--- a/src/embeddings/error.rs
+++ b/src/embeddings/error.rs
@@ -1,0 +1,49 @@
+//! Embedding error types
+//!
+//! Unified error type for all embedding operations.
+
+use thiserror::Error;
+
+/// Errors that can occur during embedding operations
+#[derive(Error, Debug)]
+pub enum EmbeddingError {
+    /// Model initialization failed
+    #[error("Model initialization failed: {0}")]
+    ModelInit(String),
+
+    /// Embedding generation failed
+    #[error("Embedding generation failed: {0}")]
+    EmbedFailed(String),
+
+    /// No embedding was generated (empty result from model)
+    #[error("No embedding generated")]
+    NoEmbeddingGenerated,
+
+    /// Async task join failed
+    #[error("Async task failed: {0}")]
+    TaskJoin(String),
+}
+
+impl EmbeddingError {
+    /// Create a model initialization error
+    pub fn model_init(msg: impl Into<String>) -> Self {
+        Self::ModelInit(msg.into())
+    }
+
+    /// Create an embed failed error
+    pub fn embed_failed(msg: impl Into<String>) -> Self {
+        Self::EmbedFailed(msg.into())
+    }
+
+    /// Create a task join error
+    pub fn task_join(msg: impl Into<String>) -> Self {
+        Self::TaskJoin(msg.into())
+    }
+}
+
+// Convert to Box<dyn Error + Send> for compatibility with existing code
+impl From<EmbeddingError> for Box<dyn std::error::Error + Send> {
+    fn from(err: EmbeddingError) -> Self {
+        Box::new(err)
+    }
+}

--- a/src/embeddings/mod.rs
+++ b/src/embeddings/mod.rs
@@ -2,6 +2,9 @@
 //!
 //! Generates embeddings for code chunks using local ONNX models
 
+mod error;
+pub use error::EmbeddingError;
+
 /// Embedding dimension for all-MiniLM-L6-v2
 pub const EMBEDDING_DIM: usize = 384;
 
@@ -34,7 +37,7 @@ impl EmbeddingGenerator {
     /// - 384 dimensions
     /// - ~80MB download
     /// - Good balance of speed and quality
-    pub fn new() -> Result<Self, Box<dyn std::error::Error>> {
+    pub fn new() -> Result<Self, EmbeddingError> {
         // Debug: Log environment variables critical for CUDA
         tracing::info!("=== CUDA INITIALIZATION DEBUG ===");
         tracing::info!("CUDA_HOME: {:?}", std::env::var("CUDA_HOME").ok());
@@ -89,7 +92,8 @@ impl EmbeddingGenerator {
             InitOptions::new(EmbeddingModel::AllMiniLML6V2)
                 .with_show_download_progress(true)
                 .with_execution_providers(execution_providers),
-        )?;
+        )
+        .map_err(|e| EmbeddingError::model_init(e.to_string()))?;
 
         tracing::info!(
             "EmbeddingGenerator initialized successfully (CUDA: {}, dimensions: 384)",
@@ -108,64 +112,64 @@ impl EmbeddingGenerator {
     }
 
     /// Generate embedding for a single text
-    pub fn embed(&self, text: &str) -> Result<Embedding, Box<dyn std::error::Error + Send>> {
+    pub fn embed(&self, text: &str) -> Result<Embedding, EmbeddingError> {
         let mut model = self.model.lock().unwrap();
         let embeddings = model.embed(vec![text], None)
-            .map_err(|e| Box::new(std::io::Error::new(std::io::ErrorKind::Other, e.to_string())) as Box<dyn std::error::Error + Send>)?;
+            .map_err(|e| EmbeddingError::embed_failed(e.to_string()))?;
         embeddings
             .into_iter()
             .next()
-            .ok_or_else(|| Box::new(std::io::Error::new(std::io::ErrorKind::Other, "No embedding generated")) as Box<dyn std::error::Error + Send>)
+            .ok_or(EmbeddingError::NoEmbeddingGenerated)
     }
 
     /// Generate embedding for a single text, non-blocking (runs on blocking thread pool)
-    pub async fn embed_async(&self, text: String) -> Result<Embedding, Box<dyn std::error::Error + Send>> {
+    pub async fn embed_async(&self, text: String) -> Result<Embedding, EmbeddingError> {
         let model = self.model.clone();
         tokio::task::spawn_blocking(move || {
             let mut model = model.lock().unwrap();
             let embeddings = model.embed(vec![&text], None)
-                .map_err(|e| Box::new(std::io::Error::new(std::io::ErrorKind::Other, e.to_string())) as Box<dyn std::error::Error + Send>)?;
+                .map_err(|e| EmbeddingError::embed_failed(e.to_string()))?;
             embeddings
                 .into_iter()
                 .next()
-                .ok_or_else(|| Box::new(std::io::Error::new(std::io::ErrorKind::Other, "No embedding generated")) as Box<dyn std::error::Error + Send>)
+                .ok_or(EmbeddingError::NoEmbeddingGenerated)
         })
         .await
-        .map_err(|e| Box::new(std::io::Error::new(std::io::ErrorKind::Other, e.to_string())) as Box<dyn std::error::Error + Send>)?
+        .map_err(|e| EmbeddingError::task_join(e.to_string()))?
     }
 
     /// Generate embeddings for multiple texts (batch processing)
     pub fn embed_batch(
         &self,
         texts: Vec<String>,
-    ) -> Result<Vec<Embedding>, Box<dyn std::error::Error + Send>> {
+    ) -> Result<Vec<Embedding>, EmbeddingError> {
         let text_refs: Vec<&str> = texts.iter().map(|s| s.as_str()).collect();
         let mut model = self.model.lock().unwrap();
-        Ok(model.embed(text_refs, None)
-            .map_err(|e| Box::new(std::io::Error::new(std::io::ErrorKind::Other, e.to_string())) as Box<dyn std::error::Error + Send>)?)
+        model.embed(text_refs, None)
+            .map_err(|e| EmbeddingError::embed_failed(e.to_string()))
     }
 
     /// Generate embeddings for multiple texts, non-blocking (runs on blocking thread pool)
     pub async fn embed_batch_async(
         &self,
         texts: Vec<String>,
-    ) -> Result<Vec<Embedding>, Box<dyn std::error::Error + Send>> {
+    ) -> Result<Vec<Embedding>, EmbeddingError> {
         let model = self.model.clone();
         tokio::task::spawn_blocking(move || {
             let text_refs: Vec<&str> = texts.iter().map(|s| s.as_str()).collect();
             let mut model = model.lock().unwrap();
             model.embed(text_refs, None)
-                .map_err(|e| Box::new(std::io::Error::new(std::io::ErrorKind::Other, e.to_string())) as Box<dyn std::error::Error + Send>)
+                .map_err(|e| EmbeddingError::embed_failed(e.to_string()))
         })
         .await
-        .map_err(|e| Box::new(std::io::Error::new(std::io::ErrorKind::Other, e.to_string())) as Box<dyn std::error::Error + Send>)?
+        .map_err(|e| EmbeddingError::task_join(e.to_string()))?
     }
 
     /// Generate embeddings for code chunks
     pub fn embed_chunks(
         &self,
         chunks: &[CodeChunk],
-    ) -> Result<Vec<ChunkWithEmbedding>, Box<dyn std::error::Error + Send>> {
+    ) -> Result<Vec<ChunkWithEmbedding>, EmbeddingError> {
         // Format chunks for embedding
         let formatted: Vec<String> = chunks
             .iter()
@@ -219,7 +223,7 @@ impl EmbeddingPipeline {
         &self,
         chunks: Vec<CodeChunk>,
         mut progress: F,
-    ) -> Result<Vec<ChunkWithEmbedding>, Box<dyn std::error::Error + Send>>
+    ) -> Result<Vec<ChunkWithEmbedding>, EmbeddingError>
     where
         F: FnMut(usize, usize),
     {

--- a/src/embeddings/mod.rs
+++ b/src/embeddings/mod.rs
@@ -106,13 +106,31 @@ impl EmbeddingGenerator {
 
     /// Generate embedding for a single text
     pub fn embed(&self, text: &str) -> Result<Embedding, Box<dyn std::error::Error + Send>> {
-        let mut model = self.model.lock().unwrap();
-        let embeddings = model.embed(vec![text], None)
+        let model = self.model.clone();
+        let text = text.to_string();
+        let mut model = model.lock().unwrap();
+        let embeddings = model.embed(vec![&text], None)
             .map_err(|e| Box::new(std::io::Error::new(std::io::ErrorKind::Other, e.to_string())) as Box<dyn std::error::Error + Send>)?;
         embeddings
             .into_iter()
             .next()
             .ok_or_else(|| Box::new(std::io::Error::new(std::io::ErrorKind::Other, "No embedding generated")) as Box<dyn std::error::Error + Send>)
+    }
+
+    /// Generate embedding for a single text, non-blocking (runs on blocking thread pool)
+    pub async fn embed_async(&self, text: String) -> Result<Embedding, Box<dyn std::error::Error + Send>> {
+        let model = self.model.clone();
+        tokio::task::spawn_blocking(move || {
+            let mut model = model.lock().unwrap();
+            let embeddings = model.embed(vec![&text], None)
+                .map_err(|e| Box::new(std::io::Error::new(std::io::ErrorKind::Other, e.to_string())) as Box<dyn std::error::Error + Send>)?;
+            embeddings
+                .into_iter()
+                .next()
+                .ok_or_else(|| Box::new(std::io::Error::new(std::io::ErrorKind::Other, "No embedding generated")) as Box<dyn std::error::Error + Send>)
+        })
+        .await
+        .map_err(|e| Box::new(std::io::Error::new(std::io::ErrorKind::Other, e.to_string())) as Box<dyn std::error::Error + Send>)?
     }
 
     /// Generate embeddings for multiple texts (batch processing)
@@ -124,6 +142,22 @@ impl EmbeddingGenerator {
         let mut model = self.model.lock().unwrap();
         Ok(model.embed(text_refs, None)
             .map_err(|e| Box::new(std::io::Error::new(std::io::ErrorKind::Other, e.to_string())) as Box<dyn std::error::Error + Send>)?)
+    }
+
+    /// Generate embeddings for multiple texts, non-blocking (runs on blocking thread pool)
+    pub async fn embed_batch_async(
+        &self,
+        texts: Vec<String>,
+    ) -> Result<Vec<Embedding>, Box<dyn std::error::Error + Send>> {
+        let model = self.model.clone();
+        tokio::task::spawn_blocking(move || {
+            let text_refs: Vec<&str> = texts.iter().map(|s| s.as_str()).collect();
+            let mut model = model.lock().unwrap();
+            model.embed(text_refs, None)
+                .map_err(|e| Box::new(std::io::Error::new(std::io::ErrorKind::Other, e.to_string())) as Box<dyn std::error::Error + Send>)
+        })
+        .await
+        .map_err(|e| Box::new(std::io::Error::new(std::io::ErrorKind::Other, e.to_string())) as Box<dyn std::error::Error + Send>)?
     }
 
     /// Generate embeddings for code chunks

--- a/src/embeddings/mod.rs
+++ b/src/embeddings/mod.rs
@@ -2,6 +2,9 @@
 //!
 //! Generates embeddings for code chunks using local ONNX models
 
+/// Embedding dimension for all-MiniLM-L6-v2
+pub const EMBEDDING_DIM: usize = 384;
+
 use crate::chunker::{ChunkId, CodeChunk};
 use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
 use ort::execution_providers::{CPUExecutionProvider, CUDAExecutionProvider, ExecutionProvider};
@@ -106,10 +109,8 @@ impl EmbeddingGenerator {
 
     /// Generate embedding for a single text
     pub fn embed(&self, text: &str) -> Result<Embedding, Box<dyn std::error::Error + Send>> {
-        let model = self.model.clone();
-        let text = text.to_string();
-        let mut model = model.lock().unwrap();
-        let embeddings = model.embed(vec![&text], None)
+        let mut model = self.model.lock().unwrap();
+        let embeddings = model.embed(vec![text], None)
             .map_err(|e| Box::new(std::io::Error::new(std::io::ErrorKind::Other, e.to_string())) as Box<dyn std::error::Error + Send>)?;
         embeddings
             .into_iter()

--- a/src/indexing/embedding_batcher.rs
+++ b/src/indexing/embedding_batcher.rs
@@ -1,0 +1,127 @@
+//! Batch embedding generation with memory-aware sizing
+//!
+//! Extracted from `IndexerCore` to encapsulate embedding pipeline concerns:
+//! GPU-optimized batch embedding generation and memory-aware batch sizing.
+
+use crate::chunker::CodeChunk;
+use crate::embeddings::{Embedding, EmbeddingGenerator};
+use crate::indexing::IndexingError;
+use crate::metrics::memory::MemoryMonitor;
+use std::sync::{Arc, Mutex};
+
+/// Handles batch embedding generation and memory-aware batch sizing.
+pub(crate) struct EmbeddingBatcher {
+    /// Embedding model
+    embedding_generator: EmbeddingGenerator,
+    /// Memory monitor for safe batch sizing
+    memory_monitor: Arc<Mutex<MemoryMonitor>>,
+    /// GPU batch size for embedding generation
+    gpu_batch_size: usize,
+}
+
+impl EmbeddingBatcher {
+    /// Create a new EmbeddingBatcher with a pre-constructed generator
+    pub(crate) fn new(
+        embedding_generator: EmbeddingGenerator,
+        gpu_batch_size: usize,
+    ) -> Self {
+        let memory_monitor = MemoryMonitor::new();
+        Self {
+            embedding_generator,
+            memory_monitor: Arc::new(Mutex::new(memory_monitor)),
+            gpu_batch_size,
+        }
+    }
+
+    /// Generate embeddings for chunks in batches
+    ///
+    /// Uses GPU-optimized batch size to avoid OOM on GPU memory.
+    pub(crate) fn generate_embeddings_batched(&self, chunks: &[CodeChunk]) -> Result<Vec<Embedding>, IndexingError> {
+        let chunk_texts: Vec<String> = chunks
+            .iter()
+            .map(|c| c.format_for_embedding())
+            .collect();
+
+        let mut all_embeddings = Vec::new();
+
+        for chunk_batch in chunk_texts.chunks(self.gpu_batch_size) {
+            let batch_embeddings = self.embedding_generator
+                .embed_batch(chunk_batch.to_vec())?;
+            all_embeddings.extend(batch_embeddings);
+        }
+
+        Ok(all_embeddings)
+    }
+
+    /// Calculate safe batch size for parallel processing based on available memory
+    pub(crate) fn calculate_safe_batch_size(&self) -> usize {
+        let available_mb = self.memory_monitor.lock().unwrap().available_bytes() / 1_000_000;
+
+        // Assume 15 MB per file in memory (content + AST + chunks)
+        let safe_concurrent = (available_mb / 15).max(1) as usize;
+
+        // Cap at CPU cores to avoid thrashing
+        let max_concurrent = num_cpus::get();
+
+        let batch_size = safe_concurrent.min(max_concurrent).min(100);
+
+        tracing::debug!(
+            "Memory-based batch size: {} (available: {} MB, max concurrent: {})",
+            batch_size,
+            available_mb,
+            max_concurrent
+        );
+
+        batch_size
+    }
+
+    /// Get current memory usage percentage
+    pub(crate) fn memory_usage_percent(&self) -> f64 {
+        self.memory_monitor.lock().unwrap().usage_percent()
+    }
+
+    /// Refresh memory monitor
+    pub(crate) fn refresh_memory_monitor(&self) {
+        self.memory_monitor.lock().unwrap().refresh();
+    }
+
+    /// Get current memory used in bytes
+    pub(crate) fn memory_used_bytes(&self) -> u64 {
+        self.memory_monitor.lock().unwrap().used_bytes()
+    }
+
+    /// Get reference to embedding generator
+    pub(crate) fn embedding_generator(&self) -> &EmbeddingGenerator {
+        &self.embedding_generator
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Note: tests that need EmbeddingGenerator require the model to be loaded,
+    // so we only test memory-related functionality here.
+
+    #[test]
+    fn test_calculate_safe_batch_size() {
+        // We can't easily construct an EmbeddingBatcher without a real EmbeddingGenerator,
+        // but we can test the memory monitor independently.
+        let monitor = MemoryMonitor::new();
+        let available_mb = monitor.available_bytes() / 1_000_000;
+        let safe_concurrent = (available_mb / 15).max(1) as usize;
+        let max_concurrent = num_cpus::get();
+        let batch_size = safe_concurrent.min(max_concurrent).min(100);
+
+        assert!(batch_size > 0);
+        assert!(batch_size <= 100);
+    }
+
+    #[test]
+    fn test_memory_monitor_usage() {
+        let monitor = MemoryMonitor::new();
+        let usage = monitor.usage_percent();
+        assert!(usage >= 0.0);
+        assert!(usage <= 100.0);
+    }
+}

--- a/src/indexing/error.rs
+++ b/src/indexing/error.rs
@@ -1,0 +1,30 @@
+//! Indexing error types
+
+use thiserror::Error;
+
+use crate::embeddings::EmbeddingError;
+use crate::vector_store::VectorStoreError;
+
+/// Errors that can occur during indexing operations
+#[derive(Error, Debug)]
+pub enum IndexingError {
+    /// I/O error
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// Embedding generation failed
+    #[error("Embedding error: {0}")]
+    Embedding(#[from] EmbeddingError),
+
+    /// Vector store operation failed
+    #[error("Vector store error: {0}")]
+    VectorStore(#[from] VectorStoreError),
+
+    /// Parser or chunker error
+    #[error("Parser error: {0}")]
+    Parser(String),
+
+    /// Metadata cache error
+    #[error("Cache error: {0}")]
+    Cache(String),
+}

--- a/src/indexing/errors.rs
+++ b/src/indexing/errors.rs
@@ -78,7 +78,7 @@ impl Default for ErrorCollector {
 }
 
 /// Categorize an error based on its message
-pub fn categorize_error(error: &anyhow::Error) -> ErrorCategory {
+pub fn categorize_error(error: &dyn std::error::Error) -> ErrorCategory {
     let error_str = error.to_string().to_lowercase();
 
     // Permanent errors
@@ -178,16 +178,16 @@ mod tests {
 
     #[test]
     fn test_categorize_permanent_errors() {
-        let error = anyhow::anyhow!("Permission denied");
+        let error = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "Permission denied");
         assert_eq!(categorize_error(&error), ErrorCategory::Permanent);
 
-        let error = anyhow::anyhow!("File not found");
+        let error = std::io::Error::new(std::io::ErrorKind::NotFound, "File not found");
         assert_eq!(categorize_error(&error), ErrorCategory::Permanent);
     }
 
     #[test]
     fn test_categorize_transient_errors() {
-        let error = anyhow::anyhow!("Network timeout");
+        let error = std::io::Error::new(std::io::ErrorKind::TimedOut, "Network timeout");
         assert_eq!(categorize_error(&error), ErrorCategory::Transient);
     }
 }

--- a/src/indexing/file_processor.rs
+++ b/src/indexing/file_processor.rs
@@ -1,0 +1,191 @@
+//! File processing, security filtering, and metadata cache operations
+//!
+//! Extracted from `IndexerCore` to encapsulate file-level concerns:
+//! sensitive file filtering, secrets scanning, size checks, and
+//! change detection via the metadata cache.
+
+use crate::indexing::IndexingError;
+use crate::metadata_cache::MetadataCache;
+use crate::security::secrets::SecretsScanner;
+use crate::security::SensitiveFileFilter;
+use std::path::Path;
+
+/// Handles file filtering, security scanning, and change detection.
+pub(crate) struct FileProcessor {
+    /// Metadata cache for incremental change detection
+    metadata_cache: MetadataCache,
+    /// Secrets scanner for content-level security
+    secrets_scanner: SecretsScanner,
+    /// File filter for path-level security
+    file_filter: SensitiveFileFilter,
+    /// Maximum file size to process (bytes)
+    max_file_size: u64,
+}
+
+impl FileProcessor {
+    /// Create a new FileProcessor
+    pub(crate) fn new(
+        cache_path: &Path,
+        max_file_size: u64,
+    ) -> Result<Self, IndexingError> {
+        let metadata_cache = MetadataCache::new(cache_path)
+            .map_err(|e| IndexingError::Cache(e.to_string()))?;
+        let secrets_scanner = SecretsScanner::new();
+        let file_filter = SensitiveFileFilter::default();
+
+        Ok(Self {
+            metadata_cache,
+            secrets_scanner,
+            file_filter,
+            max_file_size,
+        })
+    }
+
+    /// Check if a file should be processed (security and size checks)
+    pub(crate) fn should_process_file(&self, file_path: &Path) -> Result<bool, IndexingError> {
+        // Check sensitive file filter
+        if !self.file_filter.should_index(file_path) {
+            tracing::warn!("Excluding sensitive file: {}", file_path.display());
+            return Ok(false);
+        }
+
+        // Check file size
+        let metadata = std::fs::metadata(file_path)?;
+
+        if metadata.len() > self.max_file_size {
+            tracing::warn!(
+                "Skipping large file: {} ({:.2} MB exceeds {:.2} MB limit)",
+                file_path.display(),
+                metadata.len() as f64 / 1_000_000.0,
+                self.max_file_size as f64 / 1_000_000.0
+            );
+            return Ok(false);
+        }
+
+        Ok(true)
+    }
+
+    /// Fast check if file has likely changed using only stat info (mtime + size).
+    /// Avoids reading file content. Use as a pre-filter before `has_file_changed`.
+    pub(crate) fn has_stat_changed(&self, file_path: &Path) -> Result<bool, IndexingError> {
+        let file_path_str = file_path.to_string_lossy().to_string();
+        let stat = crate::metadata_cache::FileStat::from_path(file_path)
+            .map_err(|e| IndexingError::Cache(e.to_string()))?;
+        self.metadata_cache.has_stat_changed(&file_path_str, &stat)
+            .map_err(|e| IndexingError::Cache(e.to_string()))
+    }
+
+    /// Check if file has changed (using metadata cache, reads content hash)
+    pub(crate) fn has_file_changed(&self, file_path: &Path, content: &str) -> Result<bool, IndexingError> {
+        let file_path_str = file_path.to_string_lossy().to_string();
+        self.metadata_cache.has_changed(&file_path_str, content)
+            .map_err(|e| IndexingError::Cache(e.to_string()))
+    }
+
+    /// Update metadata cache for a file
+    pub(crate) fn update_file_metadata(&self, file_path: &Path, content: &str) -> Result<(), IndexingError> {
+        let file_path_str = file_path.to_string_lossy().to_string();
+        let metadata = std::fs::metadata(file_path)?;
+        let file_meta = crate::metadata_cache::FileMetadata::from_content(
+            content,
+            metadata
+                .modified()?
+                .duration_since(std::time::UNIX_EPOCH)
+                .map_err(|e| IndexingError::Cache(e.to_string()))?
+                .as_secs(),
+            metadata.len(),
+        );
+        self.metadata_cache.set(&file_path_str, &file_meta)
+            .map_err(|e| IndexingError::Cache(e.to_string()))
+    }
+
+    /// Check content for secrets; returns Err if secrets detected
+    pub(crate) fn check_secrets(&self, file_path: &Path, content: &str) -> Result<(), IndexingError> {
+        if self.secrets_scanner.should_exclude(content) {
+            let summary = self.secrets_scanner.scan_summary(content);
+            tracing::warn!(
+                "Excluding file with secrets: {}\n{}",
+                file_path.display(),
+                summary
+            );
+            return Err(IndexingError::Parser("Contains secrets".into()));
+        }
+        Ok(())
+    }
+
+    /// Get reference to metadata cache
+    pub(crate) fn metadata_cache(&self) -> &MetadataCache {
+        &self.metadata_cache
+    }
+
+    /// Clear metadata cache
+    pub(crate) fn clear_metadata_cache(&self) -> Result<(), IndexingError> {
+        self.metadata_cache
+            .clear()
+            .map_err(|e| IndexingError::Cache(e.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_file_processor_creation() {
+        let temp_dir = TempDir::new().unwrap();
+        let cache_path = temp_dir.path().join("cache");
+
+        let fp = FileProcessor::new(&cache_path, 10_000_000);
+        assert!(fp.is_ok(), "Failed to create FileProcessor: {:?}", fp.err());
+    }
+
+    #[test]
+    fn test_should_process_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let cache_path = temp_dir.path().join("cache");
+        let fp = FileProcessor::new(&cache_path, 10_000_000).unwrap();
+
+        let test_file = temp_dir.path().join("test.rs");
+        std::fs::write(&test_file, "fn test() {}").unwrap();
+
+        let result = fp.should_process_file(&test_file);
+        assert!(result.is_ok());
+        assert!(result.unwrap());
+    }
+
+    #[test]
+    fn test_should_process_file_too_large() {
+        let temp_dir = TempDir::new().unwrap();
+        let cache_path = temp_dir.path().join("cache");
+        let fp = FileProcessor::new(&cache_path, 10).unwrap(); // 10 byte limit
+
+        let test_file = temp_dir.path().join("test.rs");
+        std::fs::write(&test_file, "fn this_is_longer_than_ten_bytes() {}").unwrap();
+
+        let result = fp.should_process_file(&test_file);
+        assert!(result.is_ok());
+        assert!(!result.unwrap());
+    }
+
+    #[test]
+    fn test_check_secrets_clean() {
+        let temp_dir = TempDir::new().unwrap();
+        let cache_path = temp_dir.path().join("cache");
+        let fp = FileProcessor::new(&cache_path, 10_000_000).unwrap();
+
+        let test_file = temp_dir.path().join("test.rs");
+        let result = fp.check_secrets(&test_file, "fn normal_code() {}");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_clear_metadata_cache() {
+        let temp_dir = TempDir::new().unwrap();
+        let cache_path = temp_dir.path().join("cache");
+        let fp = FileProcessor::new(&cache_path, 10_000_000).unwrap();
+
+        let result = fp.clear_metadata_cache();
+        assert!(result.is_ok());
+    }
+}

--- a/src/indexing/incremental.rs
+++ b/src/indexing/incremental.rs
@@ -11,7 +11,7 @@
 
 use crate::indexing::merkle::{ChangeSet, FileSystemMerkle};
 use crate::indexing::unified::{IndexFileResult, IndexStats, UnifiedIndexer};
-use anyhow::{Context, Result};
+use anyhow::Result;
 use std::path::{Path, PathBuf};
 use tracing;
 

--- a/src/indexing/indexer_core.rs
+++ b/src/indexing/indexer_core.rs
@@ -1,33 +1,19 @@
-//! Core indexing logic for file processing and embedding generation
+//! Core indexing logic — thin facade over FileProcessor, Chunker, and EmbeddingBatcher
 //!
-//! This module contains the core business logic for indexing operations,
-//! including file processing, security filtering, chunking, and batch embedding generation.
-//!
-//! ## Overview
-//!
-//! The `IndexerCore` provides:
-//! - **Secure file processing**: Secrets scanning and sensitive file filtering
-//! - **Change detection**: Metadata cache for incremental indexing
-//! - **Tree-sitter parsing**: Accurate Rust AST parsing
-//! - **Symbol-based chunking**: Semantic code chunk generation
-//! - **Batch embeddings**: GPU-optimized embedding generation
-//! - **Memory monitoring**: Safe batch sizing based on available RAM
+//! `IndexerCore` orchestrates file processing and embedding generation by delegating
+//! to focused sub-components:
+//! - [`FileProcessor`](super::file_processor::FileProcessor): security filtering, change detection, metadata cache
+//! - [`EmbeddingBatcher`](super::embedding_batcher::EmbeddingBatcher): GPU-optimized batch embedding, memory monitoring
+//! - [`Chunker`]: tree-sitter parsing and semantic code chunking
 //!
 //! ## Processing Pipeline
 //!
 //! ```text
-//! File → Security Checks → Parse (rust-analyzer) → Chunk → Embeddings
-//!        ├─ Sensitive file filter
-//!        ├─ Secrets scanner
-//!        └─ Size limits
+//! File → Security Checks → Parse (tree-sitter) → Chunk → Embeddings
+//!        ├─ Sensitive file filter  ─┐
+//!        ├─ Secrets scanner         ├─ FileProcessor
+//!        └─ Size limits            ─┘
 //! ```
-//!
-//! ## Refactoring Notes
-//!
-//! This module was extracted during Phase 2 refactoring:
-//! - Moved core logic from `unified.rs` (~400 LOC of processing code)
-//! - Separates file processing from storage adapters
-//! - Thread-safe design for parallel processing with Rayon
 //!
 //! ## Examples
 //!
@@ -36,21 +22,10 @@
 //! use std::path::Path;
 //!
 //! # fn example() -> Result<(), Box<dyn std::error::Error>> {
-//! // Create indexer core
-//! let core = IndexerCore::new(
-//!     Path::new("./cache"),
-//!     None  // Use default config
-//! )?;
+//! let core = IndexerCore::new(Path::new("./cache"), None)?;
 //!
-//! // Process a file (synchronous, suitable for Rayon)
-//! let processed = core.process_file_sync(
-//!     Path::new("src/main.rs")
-//! )?;
-//!
-//! // Generate embeddings in batches
+//! let processed = core.process_file_sync(Path::new("src/main.rs"))?;
 //! let embeddings = core.generate_embeddings_batched(&processed.chunks)?;
-//!
-//! // Calculate safe batch size for parallel processing
 //! let batch_size = core.calculate_safe_batch_size();
 //! # Ok(())
 //! # }
@@ -59,14 +34,12 @@
 use crate::chunker::{Chunker, CodeChunk};
 use crate::config::IndexerCoreConfig;
 use crate::embeddings::{Embedding, EmbeddingGenerator};
-use crate::metadata_cache::MetadataCache;
-use crate::metrics::memory::MemoryMonitor;
-use crate::parser::RustParser;
-use crate::security::secrets::SecretsScanner;
-use crate::security::SensitiveFileFilter;
+use crate::indexing::embedding_batcher::EmbeddingBatcher;
+use crate::indexing::file_processor::FileProcessor;
 use crate::indexing::IndexingError;
+use crate::metadata_cache::MetadataCache;
+use crate::parser::RustParser;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 /// Result of processing a single file
@@ -82,22 +55,14 @@ pub struct ProcessedFile {
     pub parse_duration: Duration,
 }
 
-/// Core indexing logic handler
+/// Core indexing logic — facade over FileProcessor, Chunker, and EmbeddingBatcher
 pub struct IndexerCore {
+    /// File filtering, security, and change detection
+    file_processor: FileProcessor,
     /// Code chunker
     chunker: Chunker,
-    /// Embedding generator
-    embedding_generator: EmbeddingGenerator,
-    /// Metadata cache for change detection
-    metadata_cache: MetadataCache,
-    /// Secrets scanner
-    secrets_scanner: SecretsScanner,
-    /// File filter for sensitive files
-    file_filter: SensitiveFileFilter,
-    /// Memory monitor (wrapped in `Arc<Mutex>` for thread-safe interior mutability)
-    memory_monitor: Arc<Mutex<MemoryMonitor>>,
-    /// Configuration
-    config: IndexerCoreConfig,
+    /// Batch embedding generation and memory monitoring
+    embedding_batcher: EmbeddingBatcher,
 }
 
 impl IndexerCore {
@@ -106,85 +71,54 @@ impl IndexerCore {
         cache_path: &Path,
         config: Option<IndexerCoreConfig>,
     ) -> Result<Self, IndexingError> {
+        let config = config.unwrap_or_default();
+
+        let file_processor = FileProcessor::new(cache_path, config.max_file_size)?;
         let chunker = Chunker::new();
-
         let embedding_generator = EmbeddingGenerator::new()?;
-
-        let metadata_cache = MetadataCache::new(cache_path)
-            .map_err(|e| IndexingError::Cache(e.to_string()))?;
-
-        let secrets_scanner = SecretsScanner::new();
-        let file_filter = SensitiveFileFilter::default();
-        let memory_monitor = MemoryMonitor::new();
+        let embedding_batcher = EmbeddingBatcher::new(embedding_generator, config.gpu_batch_size);
 
         Ok(Self {
+            file_processor,
             chunker,
-            embedding_generator,
-            metadata_cache,
-            secrets_scanner,
-            file_filter,
-            memory_monitor: Arc::new(Mutex::new(memory_monitor)),
-            config: config.unwrap_or_default(),
+            embedding_batcher,
         })
     }
 
+    // --- File processing delegation (FileProcessor) ---
+
     /// Check if a file should be processed (security and size checks)
     pub fn should_process_file(&self, file_path: &Path) -> Result<bool, IndexingError> {
-        // Check sensitive file filter
-        if !self.file_filter.should_index(file_path) {
-            tracing::warn!("Excluding sensitive file: {}", file_path.display());
-            return Ok(false);
-        }
-
-        // Check file size
-        let metadata = std::fs::metadata(file_path)?;
-
-        if metadata.len() > self.config.max_file_size {
-            tracing::warn!(
-                "Skipping large file: {} ({:.2} MB exceeds {:.2} MB limit)",
-                file_path.display(),
-                metadata.len() as f64 / 1_000_000.0,
-                self.config.max_file_size as f64 / 1_000_000.0
-            );
-            return Ok(false);
-        }
-
-        Ok(true)
+        self.file_processor.should_process_file(file_path)
     }
 
     /// Fast check if file has likely changed using only stat info (mtime + size).
     /// Avoids reading file content. Use as a pre-filter before `has_file_changed`.
     pub fn has_stat_changed(&self, file_path: &Path) -> Result<bool, IndexingError> {
-        let file_path_str = file_path.to_string_lossy().to_string();
-        let stat = crate::metadata_cache::FileStat::from_path(file_path)
-            .map_err(|e| IndexingError::Cache(e.to_string()))?;
-        self.metadata_cache.has_stat_changed(&file_path_str, &stat)
-            .map_err(|e| IndexingError::Cache(e.to_string()))
+        self.file_processor.has_stat_changed(file_path)
     }
 
     /// Check if file has changed (using metadata cache, reads content hash)
     pub fn has_file_changed(&self, file_path: &Path, content: &str) -> Result<bool, IndexingError> {
-        let file_path_str = file_path.to_string_lossy().to_string();
-        self.metadata_cache.has_changed(&file_path_str, content)
-            .map_err(|e| IndexingError::Cache(e.to_string()))
+        self.file_processor.has_file_changed(file_path, content)
     }
 
     /// Update metadata cache for a file
     pub fn update_file_metadata(&self, file_path: &Path, content: &str) -> Result<(), IndexingError> {
-        let file_path_str = file_path.to_string_lossy().to_string();
-        let metadata = std::fs::metadata(file_path)?;
-        let file_meta = crate::metadata_cache::FileMetadata::from_content(
-            content,
-            metadata
-                .modified()?
-                .duration_since(std::time::UNIX_EPOCH)
-                .map_err(|e| IndexingError::Cache(e.to_string()))?
-                .as_secs(),
-            metadata.len(),
-        );
-        self.metadata_cache.set(&file_path_str, &file_meta)
-            .map_err(|e| IndexingError::Cache(e.to_string()))
+        self.file_processor.update_file_metadata(file_path, content)
     }
+
+    /// Get reference to metadata cache
+    pub fn metadata_cache(&self) -> &MetadataCache {
+        self.file_processor.metadata_cache()
+    }
+
+    /// Clear metadata cache
+    pub fn clear_metadata_cache(&self) -> Result<(), IndexingError> {
+        self.file_processor.clear_metadata_cache()
+    }
+
+    // --- Orchestration (uses FileProcessor + Chunker) ---
 
     /// Process a single file: parse, chunk, and prepare for indexing
     ///
@@ -192,36 +126,28 @@ impl IndexerCore {
     pub fn process_file_sync(&self, file_path: &Path) -> Result<ProcessedFile, IndexingError> {
         let parse_start = Instant::now();
 
-        // Security checks
-        if !self.should_process_file(file_path)? {
+        // Security checks (delegated to file_processor)
+        if !self.file_processor.should_process_file(file_path)? {
             return Err(IndexingError::Parser("File filtered: security check failed".into()));
         }
 
         // Fast stat-based change detection (avoids reading file content)
-        if !self.has_stat_changed(file_path)? {
+        if !self.file_processor.has_stat_changed(file_path)? {
             return Err(IndexingError::Parser("File unchanged".into()));
         }
 
         // Read file (only if stat suggests change)
         let content = std::fs::read_to_string(file_path)?;
 
-        // Secrets check
-        if self.secrets_scanner.should_exclude(&content) {
-            let summary = self.secrets_scanner.scan_summary(&content);
-            tracing::warn!(
-                "Excluding file with secrets: {}\n{}",
-                file_path.display(),
-                summary
-            );
-            return Err(IndexingError::Parser("Contains secrets".into()));
-        }
+        // Secrets check (delegated to file_processor)
+        self.file_processor.check_secrets(file_path, &content)?;
 
         // Content hash check (confirms stat-based detection)
-        if !self.has_file_changed(file_path, &content)? {
+        if !self.file_processor.has_file_changed(file_path, &content)? {
             return Err(IndexingError::Parser("File unchanged".into()));
         }
 
-        // Parse with rust-analyzer (CPU-intensive)
+        // Parse with tree-sitter (CPU-intensive)
         // Create fresh parser for thread safety
         let mut parser = RustParser::new()
             .map_err(|e| IndexingError::Parser(e.to_string()))?;
@@ -247,78 +173,38 @@ impl IndexerCore {
         })
     }
 
+    // --- Embedding delegation (EmbeddingBatcher) ---
+
     /// Generate embeddings for chunks in batches
     ///
     /// Uses GPU-optimized batch size to avoid OOM on GPU memory.
     pub fn generate_embeddings_batched(&self, chunks: &[CodeChunk]) -> Result<Vec<Embedding>, IndexingError> {
-        let chunk_texts: Vec<String> = chunks
-            .iter()
-            .map(|c| c.format_for_embedding())
-            .collect();
-
-        let mut all_embeddings = Vec::new();
-
-        for chunk_batch in chunk_texts.chunks(self.config.gpu_batch_size) {
-            let batch_embeddings = self.embedding_generator
-                .embed_batch(chunk_batch.to_vec())?;
-            all_embeddings.extend(batch_embeddings);
-        }
-
-        Ok(all_embeddings)
+        self.embedding_batcher.generate_embeddings_batched(chunks)
     }
 
     /// Calculate safe batch size for parallel processing based on available memory
     pub fn calculate_safe_batch_size(&self) -> usize {
-        let available_mb = self.memory_monitor.lock().unwrap().available_bytes() / 1_000_000;
-
-        // Assume 15 MB per file in memory (content + AST + chunks)
-        let safe_concurrent = (available_mb / 15).max(1) as usize;
-
-        // Cap at CPU cores to avoid thrashing
-        let max_concurrent = num_cpus::get();
-
-        let batch_size = safe_concurrent.min(max_concurrent).min(100);
-
-        tracing::debug!(
-            "Memory-based batch size: {} (available: {} MB, max concurrent: {})",
-            batch_size,
-            available_mb,
-            max_concurrent
-        );
-
-        batch_size
+        self.embedding_batcher.calculate_safe_batch_size()
     }
 
     /// Get current memory usage percentage
     pub fn memory_usage_percent(&self) -> f64 {
-        self.memory_monitor.lock().unwrap().usage_percent()
+        self.embedding_batcher.memory_usage_percent()
     }
 
     /// Refresh memory monitor
     pub fn refresh_memory_monitor(&self) {
-        self.memory_monitor.lock().unwrap().refresh();
+        self.embedding_batcher.refresh_memory_monitor()
     }
 
     /// Get current memory used in bytes
     pub fn memory_used_bytes(&self) -> u64 {
-        self.memory_monitor.lock().unwrap().used_bytes()
+        self.embedding_batcher.memory_used_bytes()
     }
 
     /// Get reference to embedding generator for cloning
     pub fn embedding_generator(&self) -> &EmbeddingGenerator {
-        &self.embedding_generator
-    }
-
-    /// Get reference to metadata cache
-    pub fn metadata_cache(&self) -> &MetadataCache {
-        &self.metadata_cache
-    }
-
-    /// Clear metadata cache
-    pub fn clear_metadata_cache(&self) -> Result<(), IndexingError> {
-        self.metadata_cache
-            .clear()
-            .map_err(|e| IndexingError::Cache(e.to_string()))
+        self.embedding_batcher.embedding_generator()
     }
 }
 

--- a/src/indexing/indexer_core.rs
+++ b/src/indexing/indexer_core.rs
@@ -85,7 +85,7 @@ pub struct ProcessedFile {
 /// Core indexing logic handler
 pub struct IndexerCore {
     /// Rust code parser
-    parser: RustParser,
+    _parser: RustParser,
     /// Code chunker
     chunker: Chunker,
     /// Embedding generator
@@ -124,7 +124,7 @@ impl IndexerCore {
         let memory_monitor = MemoryMonitor::new();
 
         Ok(Self {
-            parser,
+            _parser: parser,
             chunker,
             embedding_generator,
             metadata_cache,
@@ -160,7 +160,17 @@ impl IndexerCore {
         Ok(true)
     }
 
-    /// Check if file has changed (using metadata cache)
+    /// Fast check if file has likely changed using only stat info (mtime + size).
+    /// Avoids reading file content. Use as a pre-filter before `has_file_changed`.
+    pub fn has_stat_changed(&self, file_path: &Path) -> Result<bool> {
+        let file_path_str = file_path.to_string_lossy().to_string();
+        let stat = crate::metadata_cache::FileStat::from_path(file_path)
+            .map_err(|e| anyhow::anyhow!("Failed to stat file: {}", e))?;
+        self.metadata_cache.has_stat_changed(&file_path_str, &stat)
+            .map_err(|e| anyhow::anyhow!("Metadata cache error: {}", e))
+    }
+
+    /// Check if file has changed (using metadata cache, reads content hash)
     pub fn has_file_changed(&self, file_path: &Path, content: &str) -> Result<bool> {
         let file_path_str = file_path.to_string_lossy().to_string();
         self.metadata_cache.has_changed(&file_path_str, content)
@@ -194,7 +204,12 @@ impl IndexerCore {
             anyhow::bail!("File filtered: security check failed");
         }
 
-        // Read file
+        // Fast stat-based change detection (avoids reading file content)
+        if !self.has_stat_changed(file_path)? {
+            anyhow::bail!("File unchanged");
+        }
+
+        // Read file (only if stat suggests change)
         let content = std::fs::read_to_string(file_path)
             .context(format!("Failed to read file: {}", file_path.display()))?;
 
@@ -209,7 +224,7 @@ impl IndexerCore {
             anyhow::bail!("Contains secrets");
         }
 
-        // Check cache
+        // Content hash check (confirms stat-based detection)
         if !self.has_file_changed(file_path, &content)? {
             anyhow::bail!("File unchanged");
         }

--- a/src/indexing/indexer_core.rs
+++ b/src/indexing/indexer_core.rs
@@ -84,8 +84,6 @@ pub struct ProcessedFile {
 
 /// Core indexing logic handler
 pub struct IndexerCore {
-    /// Rust code parser
-    _parser: RustParser,
     /// Code chunker
     chunker: Chunker,
     /// Embedding generator
@@ -108,9 +106,6 @@ impl IndexerCore {
         cache_path: &Path,
         config: Option<IndexerCoreConfig>,
     ) -> Result<Self> {
-        let parser = RustParser::new()
-            .map_err(|e| anyhow::anyhow!("Failed to create RustParser: {}", e))?;
-
         let chunker = Chunker::new();
 
         let embedding_generator = EmbeddingGenerator::new()
@@ -124,7 +119,6 @@ impl IndexerCore {
         let memory_monitor = MemoryMonitor::new();
 
         Ok(Self {
-            _parser: parser,
             chunker,
             embedding_generator,
             metadata_cache,

--- a/src/indexing/indexer_core.rs
+++ b/src/indexing/indexer_core.rs
@@ -35,7 +35,7 @@
 //! use file_search_mcp::indexing::indexer_core::IndexerCore;
 //! use std::path::Path;
 //!
-//! # fn example() -> anyhow::Result<()> {
+//! # fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! // Create indexer core
 //! let core = IndexerCore::new(
 //!     Path::new("./cache"),
@@ -64,7 +64,7 @@ use crate::metrics::memory::MemoryMonitor;
 use crate::parser::RustParser;
 use crate::security::secrets::SecretsScanner;
 use crate::security::SensitiveFileFilter;
-use anyhow::{Context, Result};
+use crate::indexing::IndexingError;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -105,14 +105,13 @@ impl IndexerCore {
     pub fn new(
         cache_path: &Path,
         config: Option<IndexerCoreConfig>,
-    ) -> Result<Self> {
+    ) -> Result<Self, IndexingError> {
         let chunker = Chunker::new();
 
-        let embedding_generator = EmbeddingGenerator::new()
-            .map_err(|e| anyhow::anyhow!("Failed to create EmbeddingGenerator: {}", e))?;
+        let embedding_generator = EmbeddingGenerator::new()?;
 
         let metadata_cache = MetadataCache::new(cache_path)
-            .context("Failed to open MetadataCache")?;
+            .map_err(|e| IndexingError::Cache(e.to_string()))?;
 
         let secrets_scanner = SecretsScanner::new();
         let file_filter = SensitiveFileFilter::default();
@@ -130,7 +129,7 @@ impl IndexerCore {
     }
 
     /// Check if a file should be processed (security and size checks)
-    pub fn should_process_file(&self, file_path: &Path) -> Result<bool> {
+    pub fn should_process_file(&self, file_path: &Path) -> Result<bool, IndexingError> {
         // Check sensitive file filter
         if !self.file_filter.should_index(file_path) {
             tracing::warn!("Excluding sensitive file: {}", file_path.display());
@@ -138,8 +137,7 @@ impl IndexerCore {
         }
 
         // Check file size
-        let metadata = std::fs::metadata(file_path)
-            .context(format!("Failed to read file metadata: {}", file_path.display()))?;
+        let metadata = std::fs::metadata(file_path)?;
 
         if metadata.len() > self.config.max_file_size {
             tracing::warn!(
@@ -156,56 +154,56 @@ impl IndexerCore {
 
     /// Fast check if file has likely changed using only stat info (mtime + size).
     /// Avoids reading file content. Use as a pre-filter before `has_file_changed`.
-    pub fn has_stat_changed(&self, file_path: &Path) -> Result<bool> {
+    pub fn has_stat_changed(&self, file_path: &Path) -> Result<bool, IndexingError> {
         let file_path_str = file_path.to_string_lossy().to_string();
         let stat = crate::metadata_cache::FileStat::from_path(file_path)
-            .map_err(|e| anyhow::anyhow!("Failed to stat file: {}", e))?;
+            .map_err(|e| IndexingError::Cache(e.to_string()))?;
         self.metadata_cache.has_stat_changed(&file_path_str, &stat)
-            .map_err(|e| anyhow::anyhow!("Metadata cache error: {}", e))
+            .map_err(|e| IndexingError::Cache(e.to_string()))
     }
 
     /// Check if file has changed (using metadata cache, reads content hash)
-    pub fn has_file_changed(&self, file_path: &Path, content: &str) -> Result<bool> {
+    pub fn has_file_changed(&self, file_path: &Path, content: &str) -> Result<bool, IndexingError> {
         let file_path_str = file_path.to_string_lossy().to_string();
         self.metadata_cache.has_changed(&file_path_str, content)
-            .map_err(|e| anyhow::anyhow!("Metadata cache error: {}", e))
+            .map_err(|e| IndexingError::Cache(e.to_string()))
     }
 
     /// Update metadata cache for a file
-    pub fn update_file_metadata(&self, file_path: &Path, content: &str) -> Result<()> {
+    pub fn update_file_metadata(&self, file_path: &Path, content: &str) -> Result<(), IndexingError> {
         let file_path_str = file_path.to_string_lossy().to_string();
         let metadata = std::fs::metadata(file_path)?;
         let file_meta = crate::metadata_cache::FileMetadata::from_content(
             content,
             metadata
                 .modified()?
-                .duration_since(std::time::UNIX_EPOCH)?
+                .duration_since(std::time::UNIX_EPOCH)
+                .map_err(|e| IndexingError::Cache(e.to_string()))?
                 .as_secs(),
             metadata.len(),
         );
         self.metadata_cache.set(&file_path_str, &file_meta)
-            .map_err(|e| anyhow::anyhow!("Failed to update metadata cache: {}", e))
+            .map_err(|e| IndexingError::Cache(e.to_string()))
     }
 
     /// Process a single file: parse, chunk, and prepare for indexing
     ///
     /// This is a synchronous operation suitable for parallel processing with Rayon.
-    pub fn process_file_sync(&self, file_path: &Path) -> Result<ProcessedFile> {
+    pub fn process_file_sync(&self, file_path: &Path) -> Result<ProcessedFile, IndexingError> {
         let parse_start = Instant::now();
 
         // Security checks
         if !self.should_process_file(file_path)? {
-            anyhow::bail!("File filtered: security check failed");
+            return Err(IndexingError::Parser("File filtered: security check failed".into()));
         }
 
         // Fast stat-based change detection (avoids reading file content)
         if !self.has_stat_changed(file_path)? {
-            anyhow::bail!("File unchanged");
+            return Err(IndexingError::Parser("File unchanged".into()));
         }
 
         // Read file (only if stat suggests change)
-        let content = std::fs::read_to_string(file_path)
-            .context(format!("Failed to read file: {}", file_path.display()))?;
+        let content = std::fs::read_to_string(file_path)?;
 
         // Secrets check
         if self.secrets_scanner.should_exclude(&content) {
@@ -215,28 +213,28 @@ impl IndexerCore {
                 file_path.display(),
                 summary
             );
-            anyhow::bail!("Contains secrets");
+            return Err(IndexingError::Parser("Contains secrets".into()));
         }
 
         // Content hash check (confirms stat-based detection)
         if !self.has_file_changed(file_path, &content)? {
-            anyhow::bail!("File unchanged");
+            return Err(IndexingError::Parser("File unchanged".into()));
         }
 
         // Parse with rust-analyzer (CPU-intensive)
         // Create fresh parser for thread safety
         let mut parser = RustParser::new()
-            .map_err(|e| anyhow::anyhow!("Failed to create parser: {}", e))?;
+            .map_err(|e| IndexingError::Parser(e.to_string()))?;
         let parse_result = parser.parse_source_complete(&content)
-            .map_err(|e| anyhow::anyhow!("Failed to parse file: {}", e))?;
+            .map_err(|e| IndexingError::Parser(e.to_string()))?;
 
         // Chunk (CPU-intensive)
         let chunks = self.chunker.chunk_file(file_path, &content, &parse_result)
-            .map_err(|e| anyhow::anyhow!("Failed to chunk file: {}", e))?;
+            .map_err(|e| IndexingError::Parser(e.to_string()))?;
 
         if chunks.is_empty() {
             tracing::warn!("No chunks generated for {}", file_path.display());
-            anyhow::bail!("No chunks generated");
+            return Err(IndexingError::Parser("No chunks generated".into()));
         }
 
         let parse_duration = parse_start.elapsed();
@@ -252,7 +250,7 @@ impl IndexerCore {
     /// Generate embeddings for chunks in batches
     ///
     /// Uses GPU-optimized batch size to avoid OOM on GPU memory.
-    pub fn generate_embeddings_batched(&self, chunks: &[CodeChunk]) -> Result<Vec<Embedding>> {
+    pub fn generate_embeddings_batched(&self, chunks: &[CodeChunk]) -> Result<Vec<Embedding>, IndexingError> {
         let chunk_texts: Vec<String> = chunks
             .iter()
             .map(|c| c.format_for_embedding())
@@ -260,10 +258,9 @@ impl IndexerCore {
 
         let mut all_embeddings = Vec::new();
 
-        for (batch_idx, chunk_batch) in chunk_texts.chunks(self.config.gpu_batch_size).enumerate() {
+        for chunk_batch in chunk_texts.chunks(self.config.gpu_batch_size) {
             let batch_embeddings = self.embedding_generator
-                .embed_batch(chunk_batch.to_vec())
-                .map_err(|e| anyhow::anyhow!("Failed to generate embeddings (batch {}): {}", batch_idx, e))?;
+                .embed_batch(chunk_batch.to_vec())?;
             all_embeddings.extend(batch_embeddings);
         }
 
@@ -318,10 +315,10 @@ impl IndexerCore {
     }
 
     /// Clear metadata cache
-    pub fn clear_metadata_cache(&self) -> Result<()> {
+    pub fn clear_metadata_cache(&self) -> Result<(), IndexingError> {
         self.metadata_cache
             .clear()
-            .map_err(|e| anyhow::anyhow!("Failed to clear metadata cache: {}", e))
+            .map_err(|e| IndexingError::Cache(e.to_string()))
     }
 }
 

--- a/src/indexing/mod.rs
+++ b/src/indexing/mod.rs
@@ -1,6 +1,7 @@
 //! Indexing module - Unified pipeline for both Tantivy and vector store
 
 pub mod consistency;
+pub mod error;
 pub mod errors;
 pub mod incremental;
 pub mod indexer_core;
@@ -10,6 +11,7 @@ pub mod tantivy_adapter;
 pub mod unified;
 
 pub use consistency::{ConsistencyChecker, ConsistencyReport};
+pub use error::IndexingError;
 pub use errors::{ErrorCategory, ErrorCollector, ErrorDetail};
 pub use incremental::{get_snapshot_path, IncrementalIndexer};
 pub use indexer_core::{IndexerCore, ProcessedFile};

--- a/src/indexing/mod.rs
+++ b/src/indexing/mod.rs
@@ -1,8 +1,10 @@
 //! Indexing module - Unified pipeline for both Tantivy and vector store
 
 pub mod consistency;
+pub(crate) mod embedding_batcher;
 pub mod error;
 pub mod errors;
+pub(crate) mod file_processor;
 pub mod incremental;
 pub mod indexer_core;
 pub mod merkle;

--- a/src/indexing/unified.rs
+++ b/src/indexing/unified.rs
@@ -114,13 +114,19 @@ impl UnifiedIndexer {
             return Ok(IndexFileResult::Skipped);
         }
 
-        // Read file content
+        // Fast stat-based change detection (avoids reading file content)
+        if !self.core.has_stat_changed(file_path)? {
+            tracing::debug!("File unchanged (stat): {}", file_path.display());
+            return Ok(IndexFileResult::Unchanged);
+        }
+
+        // Read file content (only if stat suggests change)
         let content = std::fs::read_to_string(file_path)
             .context(format!("Failed to read file: {}", file_path.display()))?;
 
-        // Check if file changed
+        // Content hash check (confirms stat-based detection)
         if !self.core.has_file_changed(file_path, &content)? {
-            tracing::debug!("File unchanged: {}", file_path.display());
+            tracing::debug!("File unchanged (hash): {}", file_path.display());
             return Ok(IndexFileResult::Unchanged);
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
 //!
 //! Library modules for the MCP server
 
+#![warn(unreachable_pub, dead_code)]
+
 pub mod chunker;
 pub mod config;
 pub mod embeddings;

--- a/src/mcp/sync.rs
+++ b/src/mcp/sync.rs
@@ -8,7 +8,6 @@
 
 use crate::indexing::incremental::IncrementalIndexer;
 use anyhow::Result;
-use directories::ProjectDirs;
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -22,9 +21,6 @@ pub struct SyncManager {
     tracked_dirs: Arc<RwLock<HashSet<PathBuf>>>,
     /// Sync interval (default: 5 minutes)
     interval: Duration,
-    /// Base paths for cache and indices
-    cache_base: PathBuf,
-    tantivy_base: PathBuf,
 }
 
 impl SyncManager {
@@ -35,15 +31,13 @@ impl SyncManager {
     /// * `tantivy_base` - Base directory for Tantivy indices
     /// * `interval_secs` - Sync interval in seconds (default: 300 = 5 minutes)
     pub fn new(
-        cache_base: PathBuf,
-        tantivy_base: PathBuf,
+        _cache_base: PathBuf,
+        _tantivy_base: PathBuf,
         interval_secs: u64,
     ) -> Self {
         Self {
             tracked_dirs: Arc::new(RwLock::new(HashSet::new())),
             interval: Duration::from_secs(interval_secs),
-            cache_base,
-            tantivy_base,
         }
     }
 
@@ -51,15 +45,10 @@ impl SyncManager {
     ///
     /// Uses XDG-compliant directories or falls back to current directory
     pub fn with_defaults(interval_secs: u64) -> Self {
-        let data_dir = ProjectDirs::from("dev", "rust-code-mcp", "search")
-            .map(|dirs| dirs.data_dir().to_path_buf())
-            .unwrap_or_else(|| PathBuf::from(".rust-code-mcp"));
-
-        Self::new(
-            data_dir.join("cache"),
-            data_dir.join("index"),
-            interval_secs,
-        )
+        Self {
+            tracked_dirs: Arc::new(RwLock::new(HashSet::new())),
+            interval: Duration::from_secs(interval_secs),
+        }
     }
 
     /// Add a directory to track
@@ -146,23 +135,14 @@ impl SyncManager {
     /// - < 10ms if no changes
     /// - Only reindexes changed files if changes detected
     async fn sync_directory(&self, dir: &PathBuf) -> Result<()> {
-        // Create paths for this directory
-        let dir_hash = {
-            use sha2::{Digest, Sha256};
-            let mut hasher = Sha256::new();
-            hasher.update(dir.to_string_lossy().as_bytes());
-            format!("{:x}", hasher.finalize())
-        };
-
-        let cache_path = self.cache_base.join(&dir_hash);
-        let tantivy_path = self.tantivy_base.join(&dir_hash);
-        let collection_name = format!("code_chunks_{}", &dir_hash[..8]);
+        use crate::tools::project_paths::ProjectPaths;
+        let paths = ProjectPaths::from_directory(dir);
 
         // Create incremental indexer with embedded LanceDB backend
         let mut indexer = IncrementalIndexer::new(
-            &cache_path,
-            &tantivy_path,
-            &collection_name,
+            &paths.cache_path,
+            &paths.tantivy_path,
+            &paths.collection_name,
             384, // vector size for all-MiniLM-L6-v2
             None,
         )

--- a/src/mcp/sync.rs
+++ b/src/mcp/sync.rs
@@ -6,10 +6,11 @@
 //! - Uses IncrementalIndexer for fast change detection
 //! - Tracks multiple directories independently
 
+use crate::embeddings::EMBEDDING_DIM;
 use crate::indexing::incremental::IncrementalIndexer;
 use anyhow::Result;
 use std::collections::HashSet;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
@@ -27,14 +28,8 @@ impl SyncManager {
     /// Create a new sync manager
     ///
     /// # Arguments
-    /// * `cache_base` - Base directory for metadata caches
-    /// * `tantivy_base` - Base directory for Tantivy indices
     /// * `interval_secs` - Sync interval in seconds (default: 300 = 5 minutes)
-    pub fn new(
-        _cache_base: PathBuf,
-        _tantivy_base: PathBuf,
-        interval_secs: u64,
-    ) -> Self {
+    pub fn new(interval_secs: u64) -> Self {
         Self {
             tracked_dirs: Arc::new(RwLock::new(HashSet::new())),
             interval: Duration::from_secs(interval_secs),
@@ -62,7 +57,7 @@ impl SyncManager {
     }
 
     /// Remove a directory from tracking
-    pub async fn untrack_directory(&self, dir: &PathBuf) {
+    pub async fn untrack_directory(&self, dir: &Path) {
         let mut dirs = self.tracked_dirs.write().await;
         if dirs.remove(dir) {
             tracing::info!("Stopped tracking directory: {}", dir.display());
@@ -134,7 +129,7 @@ impl SyncManager {
     /// Uses IncrementalIndexer for fast change detection:
     /// - < 10ms if no changes
     /// - Only reindexes changed files if changes detected
-    async fn sync_directory(&self, dir: &PathBuf) -> Result<()> {
+    async fn sync_directory(&self, dir: &Path) -> Result<()> {
         use crate::tools::project_paths::ProjectPaths;
         let paths = ProjectPaths::from_directory(dir);
 
@@ -143,7 +138,7 @@ impl SyncManager {
             &paths.cache_path,
             &paths.tantivy_path,
             &paths.collection_name,
-            384, // vector size for all-MiniLM-L6-v2
+            EMBEDDING_DIM,
             None,
         )
         .await?;
@@ -174,7 +169,7 @@ impl SyncManager {
     }
 
     /// Trigger an immediate sync for a specific directory
-    pub async fn sync_directory_now(&self, dir: &PathBuf) -> Result<()> {
+    pub async fn sync_directory_now(&self, dir: &Path) -> Result<()> {
         tracing::info!("Manual sync triggered for: {}", dir.display());
         self.sync_directory(dir).await
     }

--- a/src/metadata_cache.rs
+++ b/src/metadata_cache.rs
@@ -25,6 +25,27 @@ pub struct FileMetadata {
     pub indexed_at: u64,
 }
 
+/// Lightweight stat info for fast change detection (avoids reading file content)
+#[derive(Debug, Clone)]
+pub struct FileStat {
+    pub last_modified: u64,
+    pub size: u64,
+}
+
+impl FileStat {
+    /// Read stat info from filesystem (cheap: no file content read)
+    pub fn from_path(path: &Path) -> Result<Self, Box<dyn std::error::Error>> {
+        let metadata = std::fs::metadata(path)?;
+        Ok(Self {
+            last_modified: metadata
+                .modified()?
+                .duration_since(std::time::UNIX_EPOCH)?
+                .as_secs(),
+            size: metadata.len(),
+        })
+    }
+}
+
 impl FileMetadata {
     /// Create new metadata from file content
     pub fn from_content(content: &str, last_modified: u64, size: u64) -> Self {
@@ -85,6 +106,18 @@ impl MetadataCache {
     pub fn remove(&self, file_path: &str) -> Result<(), Box<dyn std::error::Error>> {
         self.db.remove(file_path)?;
         Ok(())
+    }
+
+    /// Fast check if a file has likely changed using only stat info (mtime + size).
+    ///
+    /// This avoids reading file content entirely. Returns:
+    /// - `true` if file is not cached or stat differs (may need content hash to confirm)
+    /// - `false` if stat matches (file almost certainly unchanged)
+    pub fn has_stat_changed(&self, file_path: &str, stat: &FileStat) -> Result<bool, Box<dyn std::error::Error>> {
+        match self.get(file_path)? {
+            Some(cached) => Ok(cached.last_modified != stat.last_modified || cached.size != stat.size),
+            None => Ok(true), // Not in cache = needs indexing
+        }
     }
 
     /// Check if a file has changed since last indexing

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -15,9 +15,11 @@ use ra_ap_syntax::{
     AstNode, AstToken, Edition, SourceFile,
 };
 
-pub use call_graph::CallGraph;
-pub use imports::{extract_imports, extract_imports_from_ast, get_external_dependencies, Import};
-pub use type_references::{TypeReference, TypeReferenceTracker, TypeUsageContext};
+pub use imports::{extract_imports, extract_imports_from_ast, get_external_dependencies};
+
+use call_graph::CallGraph;
+use imports::Import;
+use type_references::TypeReference;
 
 /// A symbol extracted from Rust code
 #[derive(Debug, Clone, PartialEq)]
@@ -185,7 +187,7 @@ impl RustParser {
         let imports = extract_imports_from_ast(&file);
 
         // Extract type references from AST (no re-parsing)
-        let type_references = TypeReferenceTracker::build_from_ast(&file, source);
+        let type_references = type_references::build_type_references_from_ast(&file, source);
 
         Ok(ParseResult {
             symbols,

--- a/src/parser/type_references.rs
+++ b/src/parser/type_references.rs
@@ -44,17 +44,12 @@ pub enum TypeUsageContext {
 
 /// Type reference tracker
 #[derive(Debug, Default)]
-pub struct TypeReferenceTracker {
-    /// All type references found
-    _references: Vec<TypeReference>,
-}
+pub struct TypeReferenceTracker {}
 
 impl TypeReferenceTracker {
     /// Create a new empty tracker
     pub fn new() -> Self {
-        Self {
-            _references: Vec::new(),
-        }
+        Self {}
     }
 
     /// Build type references from source code (convenience wrapper that parses internally)

--- a/src/parser/type_references.rs
+++ b/src/parser/type_references.rs
@@ -42,178 +42,167 @@ pub enum TypeUsageContext {
     GenericArgument,
 }
 
-/// Type reference tracker
-#[derive(Debug, Default)]
-pub struct TypeReferenceTracker {}
+/// Build type references from source code (convenience wrapper that parses internally)
+pub(crate) fn build_type_references(source: &str) -> Vec<TypeReference> {
+    build_type_references_with_edition(source, Edition::Edition2021)
+}
 
-impl TypeReferenceTracker {
-    /// Create a new empty tracker
-    pub fn new() -> Self {
-        Self {}
-    }
+/// Build type references from source code with a specific Rust edition
+pub(crate) fn build_type_references_with_edition(source: &str, edition: Edition) -> Vec<TypeReference> {
+    let parse = SourceFile::parse(source, edition);
+    let file = parse.tree();
+    build_type_references_from_ast(&file, source)
+}
 
-    /// Build type references from source code (convenience wrapper that parses internally)
-    pub fn build(source: &str) -> Vec<TypeReference> {
-        Self::build_with_edition(source, Edition::Edition2021)
-    }
+/// Build type references from a pre-parsed AST (avoids re-parsing)
+/// Requires source string for line number calculation
+pub(crate) fn build_type_references_from_ast(file: &SourceFile, source: &str) -> Vec<TypeReference> {
+    let mut refs = Vec::new();
 
-    /// Build type references from source code with a specific Rust edition
-    pub fn build_with_edition(source: &str, edition: Edition) -> Vec<TypeReference> {
-        let parse = SourceFile::parse(source, edition);
-        let file = parse.tree();
-        Self::build_from_ast(&file, source)
-    }
+    for item in file.items() {
+        match &item {
+            ast::Item::Fn(f) => {
+                let fn_name = f
+                    .name()
+                    .map(|n| n.text().to_string())
+                    .unwrap_or_default();
 
-    /// Build type references from a pre-parsed AST (avoids re-parsing)
-    /// Requires source string for line number calculation
-    pub fn build_from_ast(file: &SourceFile, source: &str) -> Vec<TypeReference> {
-        let mut refs = Vec::new();
-
-        for item in file.items() {
-            match &item {
-                ast::Item::Fn(f) => {
-                    let fn_name = f
-                        .name()
-                        .map(|n| n.text().to_string())
-                        .unwrap_or_default();
-
-                    // Parameters
-                    if let Some(params) = f.param_list() {
-                        for param in params.params() {
-                            if let Some(ty) = param.ty() {
-                                extract_types_from_type(
-                                    &ty,
-                                    source,
-                                    &mut refs,
-                                    TypeUsageContext::FunctionParameter {
-                                        function_name: fn_name.clone(),
-                                    },
-                                );
-                            }
-                        }
-                    }
-
-                    // Return type
-                    if let Some(ret) = f.ret_type() {
-                        if let Some(ty) = ret.ty() {
+                // Parameters
+                if let Some(params) = f.param_list() {
+                    for param in params.params() {
+                        if let Some(ty) = param.ty() {
                             extract_types_from_type(
                                 &ty,
                                 source,
                                 &mut refs,
-                                TypeUsageContext::FunctionReturn {
+                                TypeUsageContext::FunctionParameter {
                                     function_name: fn_name.clone(),
                                 },
                             );
                         }
                     }
                 }
-                ast::Item::Struct(s) => {
-                    let struct_name = s
-                        .name()
-                        .map(|n| n.text().to_string())
-                        .unwrap_or_default();
 
-                    if let Some(field_list) = s.field_list() {
-                        match field_list {
-                            ast::FieldList::RecordFieldList(record) => {
-                                for field in record.fields() {
-                                    let field_name = field
-                                        .name()
-                                        .map(|n| n.text().to_string())
-                                        .unwrap_or_default();
-                                    if let Some(ty) = field.ty() {
-                                        extract_types_from_type(
-                                            &ty,
-                                            source,
-                                            &mut refs,
-                                            TypeUsageContext::StructField {
-                                                struct_name: struct_name.clone(),
-                                                field_name,
-                                            },
-                                        );
-                                    }
+                // Return type
+                if let Some(ret) = f.ret_type() {
+                    if let Some(ty) = ret.ty() {
+                        extract_types_from_type(
+                            &ty,
+                            source,
+                            &mut refs,
+                            TypeUsageContext::FunctionReturn {
+                                function_name: fn_name.clone(),
+                            },
+                        );
+                    }
+                }
+            }
+            ast::Item::Struct(s) => {
+                let struct_name = s
+                    .name()
+                    .map(|n| n.text().to_string())
+                    .unwrap_or_default();
+
+                if let Some(field_list) = s.field_list() {
+                    match field_list {
+                        ast::FieldList::RecordFieldList(record) => {
+                            for field in record.fields() {
+                                let field_name = field
+                                    .name()
+                                    .map(|n| n.text().to_string())
+                                    .unwrap_or_default();
+                                if let Some(ty) = field.ty() {
+                                    extract_types_from_type(
+                                        &ty,
+                                        source,
+                                        &mut refs,
+                                        TypeUsageContext::StructField {
+                                            struct_name: struct_name.clone(),
+                                            field_name,
+                                        },
+                                    );
                                 }
                             }
-                            ast::FieldList::TupleFieldList(tuple) => {
-                                for (i, field) in tuple.fields().enumerate() {
-                                    if let Some(ty) = field.ty() {
-                                        extract_types_from_type(
-                                            &ty,
-                                            source,
-                                            &mut refs,
-                                            TypeUsageContext::StructField {
-                                                struct_name: struct_name.clone(),
-                                                field_name: format!("{}", i),
-                                            },
-                                        );
-                                    }
+                        }
+                        ast::FieldList::TupleFieldList(tuple) => {
+                            for (i, field) in tuple.fields().enumerate() {
+                                if let Some(ty) = field.ty() {
+                                    extract_types_from_type(
+                                        &ty,
+                                        source,
+                                        &mut refs,
+                                        TypeUsageContext::StructField {
+                                            struct_name: struct_name.clone(),
+                                            field_name: format!("{}", i),
+                                        },
+                                    );
                                 }
                             }
                         }
                     }
                 }
-                ast::Item::Impl(i) => {
-                    let type_name = i.self_ty().map(|t| t.syntax().text().to_string());
-                    let trait_name = i.trait_().map(|t| t.syntax().text().to_string());
+            }
+            ast::Item::Impl(i) => {
+                let type_name = i.self_ty().map(|t| t.syntax().text().to_string());
+                let trait_name = i.trait_().map(|t| t.syntax().text().to_string());
 
-                    if let Some(ref tn) = type_name {
-                        refs.push(TypeReference {
-                            type_name: tn.clone(),
-                            usage_context: TypeUsageContext::ImplBlock {
-                                trait_name: trait_name.clone(),
-                            },
-                            line: line_of_offset(source, i.syntax().text_range().start().into()),
-                        });
-                    }
+                if let Some(ref tn) = type_name {
+                    refs.push(TypeReference {
+                        type_name: tn.clone(),
+                        usage_context: TypeUsageContext::ImplBlock {
+                            trait_name: trait_name.clone(),
+                        },
+                        line: line_of_offset(source, i.syntax().text_range().start().into()),
+                    });
+                }
 
-                    // Process functions inside impl block
-                    if let Some(assoc_items) = i.assoc_item_list() {
-                        for assoc in assoc_items.assoc_items() {
-                            if let ast::AssocItem::Fn(f) = assoc {
-                                let fn_name = f
-                                    .name()
-                                    .map(|n| n.text().to_string())
-                                    .unwrap_or_default();
+                // Process functions inside impl block
+                if let Some(assoc_items) = i.assoc_item_list() {
+                    for assoc in assoc_items.assoc_items() {
+                        if let ast::AssocItem::Fn(f) = assoc {
+                            let fn_name = f
+                                .name()
+                                .map(|n| n.text().to_string())
+                                .unwrap_or_default();
 
-                                // Parameters
-                                if let Some(params) = f.param_list() {
-                                    for param in params.params() {
-                                        if let Some(ty) = param.ty() {
-                                            extract_types_from_type(
-                                                &ty,
-                                                source,
-                                                &mut refs,
-                                                TypeUsageContext::FunctionParameter {
-                                                    function_name: fn_name.clone(),
-                                                },
-                                            );
-                                        }
-                                    }
-                                }
-
-                                // Return type
-                                if let Some(ret) = f.ret_type() {
-                                    if let Some(ty) = ret.ty() {
+                            // Parameters
+                            if let Some(params) = f.param_list() {
+                                for param in params.params() {
+                                    if let Some(ty) = param.ty() {
                                         extract_types_from_type(
                                             &ty,
                                             source,
                                             &mut refs,
-                                            TypeUsageContext::FunctionReturn {
+                                            TypeUsageContext::FunctionParameter {
                                                 function_name: fn_name.clone(),
                                             },
                                         );
                                     }
                                 }
                             }
+
+                            // Return type
+                            if let Some(ret) = f.ret_type() {
+                                if let Some(ty) = ret.ty() {
+                                    extract_types_from_type(
+                                        &ty,
+                                        source,
+                                        &mut refs,
+                                        TypeUsageContext::FunctionReturn {
+                                            function_name: fn_name.clone(),
+                                        },
+                                    );
+                                }
+                            }
                         }
                     }
                 }
-                _ => {}
             }
+            _ => {}
         }
-
-        refs
     }
+
+    refs
 }
 
 /// Calculate line number (1-indexed) from byte offset
@@ -302,7 +291,7 @@ mod tests {
             }
         "#;
 
-        let refs = TypeReferenceTracker::build(source);
+        let refs = build_type_references(source);
 
         let parser_refs = find_type_references(&refs, "RustParser");
         assert_eq!(parser_refs.len(), 1);
@@ -320,7 +309,7 @@ mod tests {
             }
         "#;
 
-        let refs = TypeReferenceTracker::build(source);
+        let refs = build_type_references(source);
 
         let parser_refs = find_type_references(&refs, "RustParser");
         assert_eq!(parser_refs.len(), 1);
@@ -339,7 +328,7 @@ mod tests {
             }
         "#;
 
-        let refs = TypeReferenceTracker::build(source);
+        let refs = build_type_references(source);
 
         let parser_refs = find_type_references(&refs, "RustParser");
         assert_eq!(parser_refs.len(), 1);
@@ -363,7 +352,7 @@ mod tests {
             }
         "#;
 
-        let refs = TypeReferenceTracker::build(source);
+        let refs = build_type_references(source);
 
         let parser_refs = find_type_references(&refs, "RustParser");
         assert_eq!(parser_refs.len(), 1);
@@ -381,7 +370,7 @@ mod tests {
             }
         "#;
 
-        let refs = TypeReferenceTracker::build(source);
+        let refs = build_type_references(source);
 
         let parser_refs = find_type_references(&refs, "RustParser");
         assert!(!parser_refs.is_empty());
@@ -401,7 +390,7 @@ mod tests {
             }
         "#;
 
-        let refs = TypeReferenceTracker::build(source);
+        let refs = build_type_references(source);
 
         let parser_refs = find_type_references(&refs, "RustParser");
         assert!(!parser_refs.is_empty());
@@ -431,7 +420,7 @@ mod tests {
             }
         "#;
 
-        let refs = TypeReferenceTracker::build(source);
+        let refs = build_type_references(source);
 
         let parser_refs = find_type_references(&refs, "RustParser");
         // Should find: struct field, parameter in new(), return type in get_parser()

--- a/src/parser/type_references.rs
+++ b/src/parser/type_references.rs
@@ -46,14 +46,14 @@ pub enum TypeUsageContext {
 #[derive(Debug, Default)]
 pub struct TypeReferenceTracker {
     /// All type references found
-    references: Vec<TypeReference>,
+    _references: Vec<TypeReference>,
 }
 
 impl TypeReferenceTracker {
     /// Create a new empty tracker
     pub fn new() -> Self {
         Self {
-            references: Vec::new(),
+            _references: Vec::new(),
         }
     }
 

--- a/src/search/error.rs
+++ b/src/search/error.rs
@@ -1,0 +1,26 @@
+//! Search error types
+
+use thiserror::Error;
+
+use crate::embeddings::EmbeddingError;
+use crate::vector_store::VectorStoreError;
+
+/// Errors that can occur during search operations
+#[derive(Error, Debug)]
+pub enum SearchError {
+    /// Embedding generation failed
+    #[error("Embedding error: {0}")]
+    Embedding(#[from] EmbeddingError),
+
+    /// Vector store operation failed
+    #[error("Vector store error: {0}")]
+    VectorStore(#[from] VectorStoreError),
+
+    /// BM25 search failed
+    #[error("BM25 search error: {0}")]
+    Bm25(Box<dyn std::error::Error + Send>),
+
+    /// No results found
+    #[error("No results found")]
+    NoResults,
+}

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -180,20 +180,6 @@ impl HybridSearch {
         Ok(merged.into_iter().take(limit).collect())
     }
 
-    /// Reciprocal Rank Fusion (RRF) algorithm
-    ///
-    /// Combines rankings from multiple search systems using the formula:
-    /// score(item) = sum(1 / (k + rank_i)) for all systems i where item appears
-    ///
-    /// Where k is a constant (typically 60) and rank_i is 1-indexed rank
-    fn _reciprocal_rank_fusion(
-        &self,
-        vector_results: &[VectorSearchResult],
-        bm25_results: &[(ChunkId, f32, CodeChunk)],
-    ) -> Vec<SearchResult> {
-        self.reciprocal_rank_fusion_with_k(vector_results, bm25_results, self.config.rrf_k)
-    }
-
     /// Reciprocal Rank Fusion with custom k parameter
     fn reciprocal_rank_fusion_with_k(
         &self,

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -3,10 +3,12 @@
 //! Implements Reciprocal Rank Fusion (RRF) to merge results from multiple search engines
 
 pub mod bm25;
+pub mod error;
 pub mod resilient;
 pub mod rrf_tuner;
 
 pub use bm25::Bm25Search;
+pub use error::SearchError;
 pub use resilient::ResilientHybridSearch;
 pub use rrf_tuner::{evaluate_hybrid_search, EvaluationMetrics, RRFTuner, TestQuery, TuningResult};
 
@@ -82,13 +84,13 @@ impl VectorSearch {
         &self,
         query: &str,
         limit: usize,
-    ) -> Result<Vec<VectorSearchResult>, Box<dyn std::error::Error + Send>> {
+    ) -> Result<Vec<VectorSearchResult>, SearchError> {
         // Generate embedding for the query
         let query_embedding = self.embedding_generator.embed(query)?;
 
         // Search in vector store
         self.vector_store.search(query_embedding, limit).await
-            .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send>)
+            .map_err(SearchError::VectorStore)
     }
 }
 
@@ -131,7 +133,7 @@ impl HybridSearch {
         &self,
         query: &str,
         limit: usize,
-    ) -> Result<Vec<SearchResult>, Box<dyn std::error::Error + Send>> {
+    ) -> Result<Vec<SearchResult>, SearchError> {
         self.search_with_k(query, limit, self.config.rrf_k).await
     }
 
@@ -143,7 +145,7 @@ impl HybridSearch {
         query: &str,
         limit: usize,
         rrf_k: f32,
-    ) -> Result<Vec<SearchResult>, Box<dyn std::error::Error + Send>> {
+    ) -> Result<Vec<SearchResult>, SearchError> {
         // Run vector search and BM25 search in parallel (if BM25 is available)
         let (vector_results, bm25_results) = if let Some(bm25) = &self.bm25_search {
             // BM25 search is sync, run in blocking task
@@ -159,8 +161,9 @@ impl HybridSearch {
             );
 
             let vector_results = vector_future?;
-            let bm25_results = bm25_future.map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send>)?
-                .map_err(|e| Box::new(std::io::Error::new(std::io::ErrorKind::Other, format!("{:?}", e))) as Box<dyn std::error::Error + Send>)?;
+            let bm25_results = bm25_future
+                .map_err(|e| SearchError::Bm25(Box::new(e)))?
+                .map_err(|e| SearchError::Bm25(e))?;
 
             (vector_results, bm25_results)
         } else {
@@ -254,7 +257,7 @@ impl HybridSearch {
         &self,
         query: &str,
         limit: usize,
-    ) -> Result<Vec<SearchResult>, Box<dyn std::error::Error + Send>> {
+    ) -> Result<Vec<SearchResult>, SearchError> {
         let results = self.vector_search.search(query, limit).await?;
 
         Ok(results

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -86,7 +86,7 @@ impl VectorSearch {
         limit: usize,
     ) -> Result<Vec<VectorSearchResult>, SearchError> {
         // Generate embedding for the query
-        let query_embedding = self.embedding_generator.embed(query)?;
+        let query_embedding = self.embedding_generator.embed_async(query.to_string()).await?;
 
         // Search in vector store
         self.vector_store.search(query_embedding, limit).await
@@ -190,66 +190,10 @@ impl HybridSearch {
         bm25_results: &[(ChunkId, f32, CodeChunk)],
         k: f32,
     ) -> Vec<SearchResult> {
-        let mut scores: HashMap<ChunkId, RrfScore> = HashMap::new();
-
-        // Process vector search results
-        for (rank, result) in vector_results.iter().enumerate() {
-            let rrf_score = 1.0 / (k + (rank + 1) as f32);
-            let entry = scores.entry(result.chunk_id).or_insert_with(|| RrfScore {
-                chunk_id: result.chunk_id,
-                rrf_score: 0.0,
-                vector_score: None,
-                vector_rank: None,
-                bm25_score: None,
-                bm25_rank: None,
-                chunk: result.chunk.clone(),
-            });
-
-            entry.rrf_score += rrf_score * self.config.vector_weight;
-            entry.vector_score = Some(result.score);
-            entry.vector_rank = Some(rank + 1);
-        }
-
-        // Process BM25 results
-        for (rank, (chunk_id, score, chunk)) in bm25_results.iter().enumerate() {
-            let rrf_score = 1.0 / (k + (rank + 1) as f32);
-            let entry = scores.entry(*chunk_id).or_insert_with(|| RrfScore {
-                chunk_id: *chunk_id,
-                rrf_score: 0.0,
-                vector_score: None,
-                vector_rank: None,
-                bm25_score: None,
-                bm25_rank: None,
-                chunk: chunk.clone(),
-            });
-
-            entry.rrf_score += rrf_score * self.config.bm25_weight;
-            entry.bm25_score = Some(*score);
-            entry.bm25_rank = Some(rank + 1);
-        }
-
-        // Convert to SearchResult and sort by RRF score
-        let mut results: Vec<SearchResult> = scores
-            .into_values()
-            .map(|rrf_score| SearchResult {
-                chunk_id: rrf_score.chunk_id,
-                score: rrf_score.rrf_score,
-                bm25_score: rrf_score.bm25_score,
-                vector_score: rrf_score.vector_score,
-                bm25_rank: rrf_score.bm25_rank,
-                vector_rank: rrf_score.vector_rank,
-                chunk: rrf_score.chunk,
-            })
+        let vector: Vec<_> = vector_results.iter()
+            .map(|r| (r.chunk_id, r.score, r.chunk.clone()))
             .collect();
-
-        // Sort by RRF score (descending)
-        results.sort_by(|a, b| {
-            b.score
-                .partial_cmp(&a.score)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
-
-        results
+        reciprocal_rank_fusion_core(&vector, bm25_results, k, self.config.vector_weight, self.config.bm25_weight)
     }
 
     /// Search using only vector similarity
@@ -281,66 +225,77 @@ impl HybridSearch {
         vector_results: Vec<SearchResult>,
         k: f32,
     ) -> Vec<SearchResult> {
-        let mut scores: HashMap<ChunkId, RrfScore> = HashMap::new();
-
-        // Process BM25 results
-        for (rank, result) in bm25_results.iter().enumerate() {
-            let rrf_score = 1.0 / (k + (rank + 1) as f32);
-            let entry = scores.entry(result.chunk_id).or_insert_with(|| RrfScore {
-                chunk_id: result.chunk_id,
-                rrf_score: 0.0,
-                vector_score: None,
-                vector_rank: None,
-                bm25_score: None,
-                bm25_rank: None,
-                chunk: result.chunk.clone(),
-            });
-
-            entry.rrf_score += rrf_score * 0.5; // Default weight
-            entry.bm25_score = result.bm25_score.or(Some(result.score));
-            entry.bm25_rank = Some(rank + 1);
-        }
-
-        // Process vector results
-        for (rank, result) in vector_results.iter().enumerate() {
-            let rrf_score = 1.0 / (k + (rank + 1) as f32);
-            let entry = scores.entry(result.chunk_id).or_insert_with(|| RrfScore {
-                chunk_id: result.chunk_id,
-                rrf_score: 0.0,
-                vector_score: None,
-                vector_rank: None,
-                bm25_score: None,
-                bm25_rank: None,
-                chunk: result.chunk.clone(),
-            });
-
-            entry.rrf_score += rrf_score * 0.5; // Default weight
-            entry.vector_score = result.vector_score.or(Some(result.score));
-            entry.vector_rank = Some(rank + 1);
-        }
-
-        // Convert to SearchResult and sort
-        let mut results: Vec<SearchResult> = scores
-            .into_values()
-            .map(|rrf_score| SearchResult {
-                chunk_id: rrf_score.chunk_id,
-                score: rrf_score.rrf_score,
-                bm25_score: rrf_score.bm25_score,
-                vector_score: rrf_score.vector_score,
-                bm25_rank: rrf_score.bm25_rank,
-                vector_rank: rrf_score.vector_rank,
-                chunk: rrf_score.chunk,
-            })
+        let bm25: Vec<_> = bm25_results.into_iter()
+            .map(|r| (r.chunk_id, r.bm25_score.unwrap_or(r.score), r.chunk))
             .collect();
-
-        results.sort_by(|a, b| {
-            b.score
-                .partial_cmp(&a.score)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
-
-        results
+        let vector: Vec<_> = vector_results.into_iter()
+            .map(|r| (r.chunk_id, r.vector_score.unwrap_or(r.score), r.chunk))
+            .collect();
+        reciprocal_rank_fusion_core(&vector, &bm25, k, 0.5, 0.5)
     }
+}
+
+/// Core Reciprocal Rank Fusion algorithm
+///
+/// Fuses two ranked result lists using the RRF formula `1/(k + rank)`.
+/// Each entry is `(ChunkId, raw_score, CodeChunk)`; the two lists are
+/// processed independently and their weighted contributions are summed.
+fn reciprocal_rank_fusion_core(
+    vector_results: &[(ChunkId, f32, CodeChunk)],
+    bm25_results: &[(ChunkId, f32, CodeChunk)],
+    k: f32,
+    vector_weight: f32,
+    bm25_weight: f32,
+) -> Vec<SearchResult> {
+    let mut scores: HashMap<ChunkId, RrfScore> = HashMap::new();
+
+    for (rank, (chunk_id, score, chunk)) in vector_results.iter().enumerate() {
+        let rrf_score = 1.0 / (k + (rank + 1) as f32);
+        let entry = scores.entry(*chunk_id).or_insert_with(|| RrfScore {
+            chunk_id: *chunk_id,
+            rrf_score: 0.0,
+            vector_score: None,
+            vector_rank: None,
+            bm25_score: None,
+            bm25_rank: None,
+            chunk: chunk.clone(),
+        });
+        entry.rrf_score += rrf_score * vector_weight;
+        entry.vector_score = Some(*score);
+        entry.vector_rank = Some(rank + 1);
+    }
+
+    for (rank, (chunk_id, score, chunk)) in bm25_results.iter().enumerate() {
+        let rrf_score = 1.0 / (k + (rank + 1) as f32);
+        let entry = scores.entry(*chunk_id).or_insert_with(|| RrfScore {
+            chunk_id: *chunk_id,
+            rrf_score: 0.0,
+            vector_score: None,
+            vector_rank: None,
+            bm25_score: None,
+            bm25_rank: None,
+            chunk: chunk.clone(),
+        });
+        entry.rrf_score += rrf_score * bm25_weight;
+        entry.bm25_score = Some(*score);
+        entry.bm25_rank = Some(rank + 1);
+    }
+
+    let mut results: Vec<SearchResult> = scores
+        .into_values()
+        .map(|s| SearchResult {
+            chunk_id: s.chunk_id,
+            score: s.rrf_score,
+            bm25_score: s.bm25_score,
+            vector_score: s.vector_score,
+            bm25_rank: s.bm25_rank,
+            vector_rank: s.vector_rank,
+            chunk: s.chunk,
+        })
+        .collect();
+
+    results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+    results
 }
 
 /// Internal structure for RRF score calculation

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -186,7 +186,7 @@ impl HybridSearch {
     /// score(item) = sum(1 / (k + rank_i)) for all systems i where item appears
     ///
     /// Where k is a constant (typically 60) and rank_i is 1-indexed rank
-    fn reciprocal_rank_fusion(
+    fn _reciprocal_rank_fusion(
         &self,
         vector_results: &[VectorSearchResult],
         bm25_results: &[(ChunkId, f32, CodeChunk)],

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -50,60 +50,6 @@ impl SemanticService {
         Ok(())
     }
 
-    /// Goto definition at position
-    pub fn goto_definition(
-        &mut self,
-        project_path: &Path,
-        file_path: &Path,
-        line: u32,
-        column: u32,
-    ) -> Result<Vec<Location>> {
-        self.get_or_load(project_path)?;
-
-        let canonical = project_path.canonicalize()?;
-        let ctx = self.projects.get(&canonical)
-            .ok_or_else(|| anyhow::anyhow!("Project not loaded"))?;
-
-        position::goto_definition(&ctx.host, &ctx.vfs, file_path, line, column)
-    }
-
-    /// Find all references at position
-    pub fn find_references(
-        &mut self,
-        project_path: &Path,
-        file_path: &Path,
-        line: u32,
-        column: u32,
-    ) -> Result<Vec<Location>> {
-        self.get_or_load(project_path)?;
-
-        let canonical = project_path.canonicalize()?;
-        let ctx = self.projects.get(&canonical)
-            .ok_or_else(|| anyhow::anyhow!("Project not loaded"))?;
-
-        position::find_references(&ctx.host, &ctx.vfs, file_path, line, column)
-    }
-
-    /// Reload project (call when files change significantly)
-    pub fn reload(&mut self, project_path: &Path) -> Result<()> {
-        let canonical = project_path.canonicalize()?;
-
-        tracing::info!("Reloading IDE for project: {}", canonical.display());
-        let (host, vfs) = loader::load_project(&canonical)?;
-
-        self.projects.insert(canonical, ProjectContext { host, vfs });
-        tracing::info!("IDE reloaded successfully");
-
-        Ok(())
-    }
-
-    /// Invalidate cached project
-    pub fn invalidate(&mut self, project_path: &Path) {
-        if let Ok(canonical) = project_path.canonicalize() {
-            self.projects.remove(&canonical);
-        }
-    }
-
     /// Search for symbols by name (for find_definition)
     pub fn symbol_search(
         &mut self,

--- a/src/tools/analysis_tools.rs
+++ b/src/tools/analysis_tools.rs
@@ -92,24 +92,6 @@ use crate::parser::RustParser;
 
 use crate::semantic::SEMANTIC;
 
-/// Helper function to recursively visit Rust files
-fn _visit_rust_files<F>(dir: &Path, visitor: &mut F) -> Result<(), String>
-where
-    F: FnMut(&Path) -> Result<(), String>,
-{
-    for entry in fs::read_dir(dir).map_err(|e| format!("Directory read error: {}", e))? {
-        let entry = entry.map_err(|e| format!("Entry read error: {}", e))?;
-        let path = entry.path();
-
-        if path.is_dir() {
-            _visit_rust_files(&path, visitor)?;
-        } else if path.extension().and_then(|s| s.to_str()) == Some("rs") {
-            visitor(&path)?;
-        }
-    }
-    Ok(())
-}
-
 /// Find the definition of a symbol by name
 pub async fn find_definition(
     symbol_name: &str,

--- a/src/tools/analysis_tools.rs
+++ b/src/tools/analysis_tools.rs
@@ -93,7 +93,7 @@ use crate::parser::RustParser;
 use crate::semantic::SEMANTIC;
 
 /// Helper function to recursively visit Rust files
-fn visit_rust_files<F>(dir: &Path, visitor: &mut F) -> Result<(), String>
+fn _visit_rust_files<F>(dir: &Path, visitor: &mut F) -> Result<(), String>
 where
     F: FnMut(&Path) -> Result<(), String>,
 {
@@ -102,7 +102,7 @@ where
         let path = entry.path();
 
         if path.is_dir() {
-            visit_rust_files(&path, visitor)?;
+            _visit_rust_files(&path, visitor)?;
         } else if path.extension().and_then(|s| s.to_str()) == Some("rs") {
             visitor(&path)?;
         }

--- a/src/tools/index_tool.rs
+++ b/src/tools/index_tool.rs
@@ -4,8 +4,7 @@
 //! incremental indexing with optional force reindex.
 
 use crate::indexing::incremental::{get_snapshot_path, IncrementalIndexer};
-use anyhow::Result;
-use directories::ProjectDirs;
+use crate::tools::project_paths::ProjectPaths;
 use rmcp::{ErrorData as McpError, model::CallToolResult, model::Content, schemars};
 use std::path::PathBuf;
 use tracing;
@@ -16,13 +15,6 @@ pub struct IndexCodebaseParams {
     pub directory: String,
     #[schemars(description = "Force full reindex even if already indexed (default: false)")]
     pub force_reindex: Option<bool>,
-}
-
-/// Get the data directory for storing caches and indices
-fn data_dir() -> PathBuf {
-    ProjectDirs::from("dev", "rust-code-mcp", "search")
-        .map(|dirs| dirs.data_dir().to_path_buf())
-        .unwrap_or_else(|| PathBuf::from(".rust-code-mcp"))
 }
 
 /// Index a codebase directory with automatic change detection
@@ -53,23 +45,13 @@ pub async fn index_codebase(
 
     tracing::info!("Indexing codebase: {} (force: {})", dir.display(), force);
 
-    // Create collection name from directory hash (same strategy as search tool)
-    let dir_hash = {
-        use sha2::{Digest, Sha256};
-        let mut hasher = Sha256::new();
-        hasher.update(dir.to_string_lossy().as_bytes());
-        format!("{:x}", hasher.finalize())
-    };
-
-    let cache_path = data_dir().join("cache").join(&dir_hash);
-    let tantivy_path = data_dir().join("index").join(&dir_hash);
-    let collection_name = format!("code_chunks_{}", &dir_hash[..8]);
+    let paths = ProjectPaths::from_directory(&dir);
 
     tracing::debug!(
         "Using collection: {}, cache: {}, index: {}",
-        collection_name,
-        cache_path.display(),
-        tantivy_path.display()
+        paths.collection_name,
+        paths.cache_path.display(),
+        paths.tantivy_path.display()
     );
 
     // Handle force reindex by deleting snapshot
@@ -85,9 +67,9 @@ pub async fn index_codebase(
 
     // Create incremental indexer with embedded LanceDB backend
     let mut indexer = IncrementalIndexer::new(
-        &cache_path,
-        &tantivy_path,
-        &collection_name,
+        &paths.cache_path,
+        &paths.tantivy_path,
+        &paths.collection_name,
         384, // all-MiniLM-L6-v2 vector size
         None,
     )
@@ -155,7 +137,7 @@ pub async fn index_codebase(
             } else {
                 "disabled"
             },
-            collection_name
+            paths.collection_name
         )
     } else {
         // Changes detected and indexed
@@ -181,7 +163,7 @@ pub async fn index_codebase(
             } else {
                 "disabled"
             },
-            collection_name
+            paths.collection_name
         )
     };
 

--- a/src/tools/index_tool.rs
+++ b/src/tools/index_tool.rs
@@ -3,6 +3,7 @@
 //! Provides the `index_codebase` tool which allows manual triggering of
 //! incremental indexing with optional force reindex.
 
+use crate::embeddings::EMBEDDING_DIM;
 use crate::indexing::incremental::{get_snapshot_path, IncrementalIndexer};
 use crate::tools::project_paths::ProjectPaths;
 use rmcp::{ErrorData as McpError, model::CallToolResult, model::Content, schemars};
@@ -70,7 +71,7 @@ pub async fn index_codebase(
         &paths.cache_path,
         &paths.tantivy_path,
         &paths.collection_name,
-        384, // all-MiniLM-L6-v2 vector size
+        EMBEDDING_DIM,
         None,
     )
     .await

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1,6 +1,7 @@
 pub mod clear_cache_tool;
 pub mod health_tool;
 pub mod index_tool;
+pub mod project_paths;
 pub mod search_tool;
 
 // Phase 1: Modular structure

--- a/src/tools/project_paths.rs
+++ b/src/tools/project_paths.rs
@@ -1,0 +1,40 @@
+//! Shared project path computation
+//!
+//! Extracts the repeated directory hash + path derivation logic
+//! used across query_tools, index_tool, and sync manager.
+
+use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
+
+use crate::tools::indexing_tools::data_dir;
+
+/// Derived paths for a project directory
+pub struct ProjectPaths {
+    pub dir_hash: String,
+    pub cache_path: PathBuf,
+    pub tantivy_path: PathBuf,
+    pub collection_name: String,
+    pub vector_path: PathBuf,
+}
+
+impl ProjectPaths {
+    /// Compute all derived paths from a project directory
+    pub fn from_directory(dir: &Path) -> Self {
+        let dir_hash = {
+            let mut hasher = Sha256::new();
+            hasher.update(dir.to_string_lossy().as_bytes());
+            format!("{:x}", hasher.finalize())
+        };
+
+        let base = data_dir();
+        let collection_name = format!("code_chunks_{}", &dir_hash[..8]);
+
+        Self {
+            cache_path: base.join("cache").join(&dir_hash),
+            tantivy_path: base.join("index").join(&dir_hash),
+            vector_path: base.join("cache").join("vectors").join(&collection_name),
+            collection_name,
+            dir_hash,
+        }
+    }
+}

--- a/src/tools/query_tools.rs
+++ b/src/tools/query_tools.rs
@@ -11,7 +11,7 @@ use std::fs;
 use std::path::Path;
 use tracing;
 
-use crate::embeddings::EmbeddingGenerator;
+use crate::embeddings::{EmbeddingGenerator, EMBEDDING_DIM};
 use crate::search::HybridSearch;
 use crate::tools::project_paths::ProjectPaths;
 use crate::vector_store::VectorStore;
@@ -128,7 +128,7 @@ async fn ensure_indexed(
         &paths.cache_path,
         &paths.tantivy_path,
         &paths.collection_name,
-        384,
+        EMBEDDING_DIM,
         None,
     )
     .await
@@ -163,7 +163,7 @@ async fn create_hybrid_search(
         McpError::invalid_params(format!("Failed to initialize embedding generator: {}", e), None)
     })?;
 
-    let vector_store = VectorStore::new_embedded(paths.vector_path.clone(), 384)
+    let vector_store = VectorStore::new_embedded(paths.vector_path.clone(), EMBEDDING_DIM)
         .await
         .map_err(|e| {
             McpError::invalid_params(format!("Failed to initialize vector store: {}", e), None)

--- a/src/tools/query_tools.rs
+++ b/src/tools/query_tools.rs
@@ -1,70 +1,7 @@
 //! Query tools module
 //!
-//! This module provides MCP tools for searching and querying indexed Rust codebases.
-//! It implements hybrid search combining BM25 keyword search with semantic vector search
-//! for optimal code discovery.
-//!
-//! ## Overview
-//!
-//! The query tools enable intelligent code search through:
-//! - **Hybrid Search**: Combines BM25 (keyword) + Vector (semantic) search with RRF ranking
-//! - **Semantic Search**: Pure vector-based similarity using code embeddings
-//! - **File Reading**: Safe file content retrieval with binary file detection
-//!
-//! ## MCP Tools
-//!
-//! - [`search`]: Hybrid keyword + semantic search (automatically indexes if needed)
-//! - [`get_similar_code`]: Find semantically similar code snippets using embeddings
-//! - [`read_file_content`]: Read and validate file contents
-//!
-//! ## Search Architecture
-//!
-//! ```text
-//! Query → HybridSearch
-//!     ├─ BM25 Search (Tantivy)      → Keyword matches
-//!     ├─ Vector Search (LanceDB)    → Semantic matches
-//!     └─ RRF Fusion                 → Combined ranking
-//! ```
-//!
-//! ## Examples
-//!
-//! ### Hybrid Search
-//! ```rust,no_run
-//! use file_search_mcp::tools::query_tools::search;
-//!
-//! # async fn example() -> Result<(), rmcp::ErrorData> {
-//! // Search with hybrid approach (BM25 + semantic)
-//! let results = search(
-//!     "/path/to/rust/project",
-//!     "async tokio spawn",
-//!     None  // No sync manager
-//! ).await?;
-//! # Ok(())
-//! # }
-//! ```
-//!
-//! ### Semantic Search
-//! ```rust,no_run
-//! use file_search_mcp::tools::query_tools::get_similar_code;
-//!
-//! # async fn example() -> Result<(), rmcp::ErrorData> {
-//! // Find code similar to a description
-//! let results = get_similar_code(
-//!     "function that parses JSON and validates schema",
-//!     "/path/to/project",
-//!     10  // Return top 10 results
-//! ).await?;
-//! # Ok(())
-//! # }
-//! ```
-//!
-//! ## Architecture
-//!
-//! This module is part of the refactored tools layer (Phase 1 refactoring).
-//! It delegates to:
-//! - `HybridSearch` for search logic
-//! - `UnifiedIndexer` for automatic indexing
-//! - `VectorStore` for semantic search
+//! MCP tools for searching and querying indexed Rust codebases.
+//! Implements hybrid search combining BM25 keyword search with semantic vector search.
 
 use rmcp::{
     ErrorData as McpError,
@@ -76,14 +13,13 @@ use tracing;
 
 use crate::embeddings::EmbeddingGenerator;
 use crate::search::HybridSearch;
+use crate::tools::project_paths::ProjectPaths;
 use crate::vector_store::VectorStore;
 
 /// Read and return the content of a specified file
 pub async fn read_file_content(file_path: &str) -> Result<CallToolResult, McpError> {
-    // Validate file path
     let file_path_obj = Path::new(file_path);
 
-    // Check if the path exists
     if !file_path_obj.exists() {
         return Err(McpError::invalid_params(
             format!("The specified path '{}' does not exist", file_path),
@@ -91,7 +27,6 @@ pub async fn read_file_content(file_path: &str) -> Result<CallToolResult, McpErr
         ));
     }
 
-    // Check if the path is a file
     if !file_path_obj.is_file() {
         return Err(McpError::invalid_params(
             format!("The specified path '{}' is not a file", file_path),
@@ -99,7 +34,6 @@ pub async fn read_file_content(file_path: &str) -> Result<CallToolResult, McpErr
         ));
     }
 
-    // Try to read the file content
     match fs::read_to_string(file_path_obj) {
         Ok(content) => {
             if content.is_empty() {
@@ -111,13 +45,9 @@ pub async fn read_file_content(file_path: &str) -> Result<CallToolResult, McpErr
             }
         }
         Err(e) => {
-            // Handle binary files or read errors
             tracing::error!("Error reading file '{}': {}", file_path_obj.display(), e);
-
-            // Try to read as binary and check if it's a binary file
             match fs::read(file_path_obj) {
                 Ok(bytes) => {
-                    // Check if it seems to be a binary file
                     if bytes.iter().any(|&b| b == 0)
                         || bytes
                             .iter()
@@ -151,15 +81,142 @@ pub async fn read_file_content(file_path: &str) -> Result<CallToolResult, McpErr
     }
 }
 
+/// Check if an index already exists for a directory (Tantivy meta.json present)
+fn index_exists(paths: &ProjectPaths) -> bool {
+    paths.tantivy_path.join("meta.json").exists()
+}
+
+/// Initialize indexer and run incremental indexing, returning stats.
+/// Only called when we actually need to index.
+async fn ensure_indexed(
+    dir_path: &Path,
+    paths: &ProjectPaths,
+    sync_manager: Option<&std::sync::Arc<crate::mcp::SyncManager>>,
+) -> Result<crate::indexing::unified::IndexStats, McpError> {
+    use crate::indexing::unified::UnifiedIndexer;
+
+    tracing::info!("Initializing unified indexer for {}", dir_path.display());
+
+    let mut indexer = UnifiedIndexer::for_embedded(
+        &paths.cache_path,
+        &paths.tantivy_path,
+        &paths.collection_name,
+        384,
+        None,
+    )
+    .await
+    .map_err(|e| McpError::invalid_params(format!("Failed to initialize indexer: {}", e), None))?;
+
+    let stats = indexer
+        .index_directory(dir_path)
+        .await
+        .map_err(|e| McpError::invalid_params(format!("Indexing failed: {}", e), None))?;
+
+    tracing::info!(
+        "Indexed {} files ({} chunks), {} unchanged, {} skipped",
+        stats.indexed_files, stats.total_chunks, stats.unchanged_files, stats.skipped_files
+    );
+
+    // Track directory for background sync
+    if let Some(ref sync_mgr) = sync_manager {
+        if stats.indexed_files > 0 || stats.unchanged_files > 0 {
+            sync_mgr.track_directory(dir_path.to_path_buf()).await;
+        }
+    }
+
+    Ok(stats)
+}
+
+/// Create a HybridSearch configured for a project directory
+async fn create_hybrid_search(
+    paths: &ProjectPaths,
+    include_bm25: bool,
+) -> Result<HybridSearch, McpError> {
+    let embedding_generator = EmbeddingGenerator::new().map_err(|e| {
+        McpError::invalid_params(format!("Failed to initialize embedding generator: {}", e), None)
+    })?;
+
+    let vector_store = VectorStore::new_embedded(paths.vector_path.clone(), 384)
+        .await
+        .map_err(|e| {
+            McpError::invalid_params(format!("Failed to initialize vector store: {}", e), None)
+        })?;
+
+    let bm25_search = if include_bm25 {
+        use crate::indexing::tantivy_adapter::TantivyAdapter;
+        use crate::config::indexer::TantivyConfig;
+        let tantivy_config = TantivyConfig::default(&paths.tantivy_path);
+        TantivyAdapter::new(tantivy_config)
+            .ok()
+            .and_then(|adapter| adapter.create_bm25_search().ok())
+    } else {
+        None
+    };
+
+    Ok(HybridSearch::with_defaults(
+        embedding_generator,
+        vector_store,
+        bm25_search,
+    ))
+}
+
+/// Format search results into a display string
+fn format_results(
+    results: &[crate::search::SearchResult],
+    keyword: &str,
+    stats: Option<&crate::indexing::unified::IndexStats>,
+) -> String {
+    if results.is_empty() {
+        let mut s = format!("No results found for '{}'.", keyword);
+        if let Some(st) = stats {
+            s.push_str(&format!(
+                "\nIndexed {} files ({} chunks), {} unchanged, {} skipped",
+                st.indexed_files, st.total_chunks, st.unchanged_files, st.skipped_files
+            ));
+        }
+        return s;
+    }
+
+    let mut result_str = format!("Found {} results for '{}':\n\n", results.len(), keyword);
+
+    for (idx, result) in results.iter().enumerate() {
+        result_str.push_str(&format!(
+            "{}. Score: {:.4} | File: {} | Symbol: {} ({})\n",
+            idx + 1,
+            result.score,
+            result.chunk.context.file_path.display(),
+            result.chunk.context.symbol_name,
+            result.chunk.context.symbol_kind,
+        ));
+        result_str.push_str(&format!(
+            "   Lines: {}-{}\n",
+            result.chunk.context.line_start, result.chunk.context.line_end
+        ));
+        if let Some(ref doc) = result.chunk.context.docstring {
+            result_str.push_str(&format!("   Doc: {}\n", doc));
+        }
+        result_str.push_str(&format!(
+            "   Preview:\n   {}\n\n",
+            result.chunk.content.lines().take(3).collect::<Vec<_>>().join("\n   ")
+        ));
+    }
+
+    if let Some(st) = stats {
+        result_str.push_str(&format!(
+            "\n--- Indexing stats: {} files indexed ({} chunks), {} unchanged, {} skipped ---",
+            st.indexed_files, st.total_chunks, st.unchanged_files, st.skipped_files
+        ));
+    }
+
+    result_str
+}
+
 /// Perform hybrid search (BM25 + Vector) on Rust code
 pub async fn search(
     directory: &str,
     keyword: &str,
     sync_manager: Option<&std::sync::Arc<crate::mcp::SyncManager>>,
 ) -> Result<CallToolResult, McpError> {
-    use crate::indexing::unified::UnifiedIndexer;
-    use crate::tools::indexing_tools::data_dir;
-
     let dir_path = Path::new(directory);
     if !dir_path.is_dir() {
         return Err(McpError::invalid_params(
@@ -168,7 +225,6 @@ pub async fn search(
         ));
     }
 
-    // Ensure the keyword is not empty
     if keyword.trim().is_empty() {
         return Err(McpError::invalid_params(
             "Search keyword is empty. Please enter a valid keyword.".to_string(),
@@ -176,76 +232,33 @@ pub async fn search(
         ));
     }
 
-    // 1. Initialize unified indexer with embedded LanceDB backend
-    // Use hash-based paths consistent with index_tool.rs
-    let dir_hash = {
-        use sha2::{Digest, Sha256};
-        let mut hasher = Sha256::new();
-        hasher.update(dir_path.to_string_lossy().as_bytes());
-        format!("{:x}", hasher.finalize())
+    let paths = ProjectPaths::from_directory(dir_path);
+
+    // Only run full indexing if no index exists yet.
+    // If index exists, skip re-indexing (background sync handles updates).
+    let stats = if index_exists(&paths) {
+        // Lightweight: just open existing index, no file walking
+        tracing::info!("Using existing index for {}", dir_path.display());
+        // Track for background sync so it stays fresh
+        if let Some(ref sync_mgr) = sync_manager {
+            sync_mgr.track_directory(dir_path.to_path_buf()).await;
+        }
+        None
+    } else {
+        Some(ensure_indexed(dir_path, &paths, sync_manager).await?)
     };
 
-    let cache_path = data_dir().join("cache").join(&dir_hash);
-    let tantivy_path = data_dir().join("index").join(&dir_hash);
-    let collection_name = format!("code_chunks_{}", &dir_hash[..8]);
-
-    tracing::info!("Initializing unified indexer for {}", dir_path.display());
-    tracing::debug!(
-        "Using collection: {}, cache: {}, index: {}",
-        collection_name,
-        cache_path.display(),
-        tantivy_path.display()
-    );
-
-    let mut indexer = UnifiedIndexer::for_embedded(
-        &cache_path,
-        &tantivy_path,
-        &collection_name,
-        384, // all-MiniLM-L6-v2 vector size
-        None,
-    )
-    .await
-    .map_err(|e| McpError::invalid_params(format!("Failed to initialize indexer: {}", e), None))?;
-
-    // 2. Index directory (incremental - only changed files)
-    tracing::info!("Indexing directory: {}", dir_path.display());
-    let stats = indexer
-        .index_directory(dir_path)
-        .await
-        .map_err(|e| McpError::invalid_params(format!("Indexing failed: {}", e), None))?;
-
-    tracing::info!(
-        "Indexed {} files ({} chunks), {} unchanged, {} skipped",
-        stats.indexed_files,
-        stats.total_chunks,
-        stats.unchanged_files,
-        stats.skipped_files
-    );
-
-    // Track directory for background sync if indexing was successful
-    if let Some(ref sync_mgr) = sync_manager {
-        if stats.indexed_files > 0 || stats.unchanged_files > 0 {
-            sync_mgr.track_directory(dir_path.to_path_buf()).await;
-            tracing::info!("Directory tracked for background sync: {}", dir_path.display());
+    // Handle case where first-time indexing produced nothing
+    if let Some(ref st) = stats {
+        if st.total_chunks == 0 && st.unchanged_files == 0 {
+            return Ok(CallToolResult::success(vec![Content::text(format!(
+                "No Rust files suitable for indexing were found in '{}'.\nSkipped files: {}",
+                directory, st.skipped_files
+            ))]));
         }
     }
 
-    if stats.total_chunks == 0 && stats.unchanged_files == 0 {
-        return Ok(CallToolResult::success(vec![Content::text(format!(
-            "No Rust files suitable for indexing were found in '{}'.\nSkipped files: {}",
-            directory, stats.skipped_files
-        ))]));
-    }
-
-    // 3. Perform hybrid search
-    let bm25_search = indexer.create_bm25_search()
-        .map_err(|e| McpError::invalid_params(format!("Failed to create BM25 search: {}", e), None))?;
-
-    let hybrid_search = HybridSearch::with_defaults(
-        indexer.embedding_generator_cloned(),
-        indexer.vector_store_cloned(),
-        Some(bm25_search),
-    );
+    let hybrid_search = create_hybrid_search(&paths, true).await?;
 
     tracing::info!("Performing hybrid search for: {}", keyword);
     let results = hybrid_search
@@ -253,45 +266,9 @@ pub async fn search(
         .await
         .map_err(|e| McpError::invalid_params(format!("Search failed: {}", e), None))?;
 
-    // 4. Format results
-    if results.is_empty() {
-        Ok(CallToolResult::success(vec![Content::text(format!(
-            "No results found for '{}'.\nIndexed {} files ({} chunks), {} unchanged, {} skipped",
-            keyword, stats.indexed_files, stats.total_chunks, stats.unchanged_files, stats.skipped_files
-        ))]))
-    } else {
-        let mut result_str = format!("Found {} results for '{}':\n\n", results.len(), keyword);
-
-        for (idx, result) in results.iter().enumerate() {
-            result_str.push_str(&format!(
-                "{}. Score: {:.4} | File: {} | Symbol: {} ({})\n",
-                idx + 1,
-                result.score,
-                result.chunk.context.file_path.display(),
-                result.chunk.context.symbol_name,
-                result.chunk.context.symbol_kind,
-            ));
-            result_str.push_str(&format!(
-                "   Lines: {}-{}\n",
-                result.chunk.context.line_start,
-                result.chunk.context.line_end
-            ));
-            if let Some(ref doc) = result.chunk.context.docstring {
-                result_str.push_str(&format!("   Doc: {}\n", doc));
-            }
-            result_str.push_str(&format!(
-                "   Preview:\n   {}\n\n",
-                result.chunk.content.lines().take(3).collect::<Vec<_>>().join("\n   ")
-            ));
-        }
-
-        result_str.push_str(&format!(
-            "\n--- Indexing stats: {} files indexed ({} chunks), {} unchanged, {} skipped ---",
-            stats.indexed_files, stats.total_chunks, stats.unchanged_files, stats.skipped_files
-        ));
-
-        Ok(CallToolResult::success(vec![Content::text(result_str)]))
-    }
+    Ok(CallToolResult::success(vec![Content::text(
+        format_results(&results, keyword, stats.as_ref()),
+    )]))
 }
 
 /// Find semantically similar code using vector search
@@ -308,50 +285,10 @@ pub async fn get_similar_code(
         ));
     }
 
-    tracing::debug!("Searching for similar code in '{}' to: {}", directory, query);
+    let paths = ProjectPaths::from_directory(dir_path);
 
-    // Calculate directory hash to determine collection name
-    let dir_hash = {
-        use sha2::{Digest, Sha256};
-        let mut hasher = Sha256::new();
-        hasher.update(dir_path.to_string_lossy().as_bytes());
-        format!("{:x}", hasher.finalize())
-    };
+    let hybrid_search = create_hybrid_search(&paths, false).await?;
 
-    let collection_name = format!("code_chunks_{}", &dir_hash[..8]);
-
-    tracing::debug!(
-        "Using collection '{}' for directory '{}'",
-        collection_name,
-        dir_path.display()
-    );
-
-    // Initialize components
-    let embedding_generator = EmbeddingGenerator::new().map_err(|e| {
-        McpError::invalid_params(
-            format!("Failed to initialize embedding generator: {}", e),
-            None,
-        )
-    })?;
-
-    // Create embedded vector store (LanceDB)
-    // Path must match index_tool.rs: data_dir()/cache/vectors/{collection_name}
-    let vector_store = {
-        use crate::tools::indexing_tools::data_dir;
-        let vector_path = data_dir().join("cache").join("vectors").join(&collection_name);
-        VectorStore::new_embedded(vector_path, 384).await.map_err(|e| {
-            McpError::invalid_params(format!("Failed to initialize vector store: {}", e), None)
-        })?
-    };
-
-    // Create hybrid search (vector-only mode)
-    let hybrid_search = HybridSearch::with_defaults(
-        embedding_generator,
-        vector_store,
-        None, // No BM25 for this tool
-    );
-
-    // Perform vector search
     let results = hybrid_search
         .vector_only_search(query, limit)
         .await
@@ -372,9 +309,9 @@ pub async fn get_similar_code(
 
     for (idx, search_result) in results.iter().enumerate() {
         let chunk = &search_result.chunk;
-        result.push_str(&format!("{}. ", idx + 1));
         result.push_str(&format!(
-            "Score: {:.4} | File: {} | Symbol: {} ({})\n",
+            "{}. Score: {:.4} | File: {} | Symbol: {} ({})\n",
+            idx + 1,
             search_result.score,
             chunk.context.file_path.display(),
             chunk.context.symbol_name,
@@ -389,12 +326,7 @@ pub async fn get_similar_code(
         }
         result.push_str(&format!(
             "   Code preview:\n   {}\n\n",
-            chunk
-                .content
-                .lines()
-                .take(3)
-                .collect::<Vec<_>>()
-                .join("\n   ")
+            chunk.content.lines().take(3).collect::<Vec<_>>().join("\n   ")
         ));
     }
 

--- a/src/tools/query_tools.rs
+++ b/src/tools/query_tools.rs
@@ -7,7 +7,7 @@ use rmcp::{
     ErrorData as McpError,
     model::{CallToolResult, Content},
 };
-use std::fs;
+use tokio::fs;
 use std::path::Path;
 use tracing;
 
@@ -34,7 +34,7 @@ pub async fn read_file_content(file_path: &str) -> Result<CallToolResult, McpErr
         ));
     }
 
-    match fs::read_to_string(file_path_obj) {
+    match fs::read_to_string(file_path_obj).await {
         Ok(content) => {
             if content.is_empty() {
                 Ok(CallToolResult::success(vec![Content::text(
@@ -46,7 +46,7 @@ pub async fn read_file_content(file_path: &str) -> Result<CallToolResult, McpErr
         }
         Err(e) => {
             tracing::error!("Error reading file '{}': {}", file_path_obj.display(), e);
-            match fs::read(file_path_obj) {
+            match fs::read(file_path_obj).await {
                 Ok(bytes) => {
                     if bytes.iter().any(|&b| b == 0)
                         || bytes

--- a/src/tools/query_tools.rs
+++ b/src/tools/query_tools.rs
@@ -81,9 +81,36 @@ pub async fn read_file_content(file_path: &str) -> Result<CallToolResult, McpErr
     }
 }
 
-/// Check if an index already exists for a directory (Tantivy meta.json present)
-fn index_exists(paths: &ProjectPaths) -> bool {
-    paths.tantivy_path.join("meta.json").exists()
+/// Try to open BM25 search for an existing index.
+/// Returns None if the index doesn't exist or is corrupt.
+fn try_open_bm25(paths: &ProjectPaths) -> Option<crate::search::bm25::Bm25Search> {
+    use crate::config::indexer::TantivyConfig;
+    use crate::indexing::tantivy_adapter::TantivyAdapter;
+
+    let config = TantivyConfig::default(&paths.tantivy_path);
+    TantivyAdapter::new(config)
+        .and_then(|adapter| adapter.create_bm25_search())
+        .ok()
+}
+
+/// Remove stale index artifacts so ensure_indexed does a full rebuild.
+/// Called when try_open_bm25 detects a corrupt or missing tantivy index.
+fn clean_stale_index(paths: &ProjectPaths, dir: &Path) {
+    use crate::indexing::incremental::get_snapshot_path;
+
+    // Remove corrupt tantivy index
+    if paths.tantivy_path.exists() {
+        std::fs::remove_dir_all(&paths.tantivy_path).ok();
+    }
+    // Remove merkle snapshot so incremental indexer does a full pass
+    let snapshot = get_snapshot_path(dir);
+    if snapshot.exists() {
+        std::fs::remove_file(&snapshot).ok();
+    }
+    // Clear metadata cache so files are re-processed
+    if paths.cache_path.exists() {
+        std::fs::remove_dir_all(&paths.cache_path).ok();
+    }
 }
 
 /// Initialize indexer and run incremental indexing, returning stats.
@@ -127,10 +154,10 @@ async fn ensure_indexed(
     Ok(stats)
 }
 
-/// Create a HybridSearch configured for a project directory
+/// Create a HybridSearch with a pre-validated BM25 search
 async fn create_hybrid_search(
     paths: &ProjectPaths,
-    include_bm25: bool,
+    bm25_search: Option<crate::search::bm25::Bm25Search>,
 ) -> Result<HybridSearch, McpError> {
     let embedding_generator = EmbeddingGenerator::new().map_err(|e| {
         McpError::invalid_params(format!("Failed to initialize embedding generator: {}", e), None)
@@ -141,17 +168,6 @@ async fn create_hybrid_search(
         .map_err(|e| {
             McpError::invalid_params(format!("Failed to initialize vector store: {}", e), None)
         })?;
-
-    let bm25_search = if include_bm25 {
-        use crate::indexing::tantivy_adapter::TantivyAdapter;
-        use crate::config::indexer::TantivyConfig;
-        let tantivy_config = TantivyConfig::default(&paths.tantivy_path);
-        TantivyAdapter::new(tantivy_config)
-            .ok()
-            .and_then(|adapter| adapter.create_bm25_search().ok())
-    } else {
-        None
-    };
 
     Ok(HybridSearch::with_defaults(
         embedding_generator,
@@ -165,6 +181,7 @@ fn format_results(
     results: &[crate::search::SearchResult],
     keyword: &str,
     stats: Option<&crate::indexing::unified::IndexStats>,
+    rebuilt: bool,
 ) -> String {
     if results.is_empty() {
         let mut s = format!("No results found for '{}'.", keyword);
@@ -177,7 +194,11 @@ fn format_results(
         return s;
     }
 
-    let mut result_str = format!("Found {} results for '{}':\n\n", results.len(), keyword);
+    let mut result_str = if rebuilt {
+        format!("Note: corrupt index detected and rebuilt.\n\nFound {} results for '{}':\n\n", results.len(), keyword)
+    } else {
+        format!("Found {} results for '{}':\n\n", results.len(), keyword)
+    };
 
     for (idx, result) in results.iter().enumerate() {
         result_str.push_str(&format!(
@@ -234,18 +255,21 @@ pub async fn search(
 
     let paths = ProjectPaths::from_directory(dir_path);
 
-    // Only run full indexing if no index exists yet.
-    // If index exists, skip re-indexing (background sync handles updates).
-    let stats = if index_exists(&paths) {
-        // Lightweight: just open existing index, no file walking
-        tracing::info!("Using existing index for {}", dir_path.display());
-        // Track for background sync so it stays fresh
+    // Try existing index; if corrupt or missing, rebuild
+    let mut bm25 = try_open_bm25(&paths);
+    let mut rebuilt = false;
+    let stats = if bm25.is_some() {
         if let Some(ref sync_mgr) = sync_manager {
             sync_mgr.track_directory(dir_path.to_path_buf()).await;
         }
         None
     } else {
-        Some(ensure_indexed(dir_path, &paths, sync_manager).await?)
+        // Corrupt or missing — clean stale caches to force full reindex
+        rebuilt = paths.tantivy_path.exists();
+        clean_stale_index(&paths, dir_path);
+        let st = ensure_indexed(dir_path, &paths, sync_manager).await?;
+        bm25 = try_open_bm25(&paths);
+        Some(st)
     };
 
     // Handle case where first-time indexing produced nothing
@@ -258,7 +282,7 @@ pub async fn search(
         }
     }
 
-    let hybrid_search = create_hybrid_search(&paths, true).await?;
+    let hybrid_search = create_hybrid_search(&paths, bm25).await?;
 
     tracing::info!("Performing hybrid search for: {}", keyword);
     let results = hybrid_search
@@ -267,7 +291,7 @@ pub async fn search(
         .map_err(|e| McpError::invalid_params(format!("Search failed: {}", e), None))?;
 
     Ok(CallToolResult::success(vec![Content::text(
-        format_results(&results, keyword, stats.as_ref()),
+        format_results(&results, keyword, stats.as_ref(), rebuilt),
     )]))
 }
 
@@ -287,7 +311,7 @@ pub async fn get_similar_code(
 
     let paths = ProjectPaths::from_directory(dir_path);
 
-    let hybrid_search = create_hybrid_search(&paths, false).await?;
+    let hybrid_search = create_hybrid_search(&paths, None).await?;
 
     let results = hybrid_search
         .vector_only_search(query, limit)

--- a/src/tools/search_tool_router.rs
+++ b/src/tools/search_tool_router.rs
@@ -62,13 +62,9 @@
 //! use file_search_mcp::tools::search_tool_router::SearchToolRouter;
 //! use file_search_mcp::mcp::SyncManager;
 //! use std::sync::Arc;
-//! use std::path::PathBuf;
 //!
 //! // Create router with background sync
-//! let sync_mgr = Arc::new(SyncManager::new(
-//!     PathBuf::from("/tmp/cache"),
-//!     PathBuf::from("/tmp/index"),
-//!     300  // 5-minute sync interval
+//! let sync_mgr = Arc::new(SyncManager::new(300  // 5-minute sync interval
 //! ));
 //! let router = SearchToolRouter::with_sync_manager(sync_mgr);
 //! ```
@@ -264,12 +260,7 @@ mod tests {
     #[test]
     fn test_router_with_sync_manager() {
         use std::sync::Arc;
-        use std::path::PathBuf;
-        let sync_mgr = Arc::new(crate::mcp::SyncManager::new(
-            PathBuf::from("/tmp/cache"),
-            PathBuf::from("/tmp/index"),
-            300, // 5 minutes
-        ));
+        let sync_mgr = Arc::new(crate::mcp::SyncManager::new(300));
         let _router = SearchToolRouter::with_sync_manager(sync_mgr);
         assert!(_router.sync_manager.is_some());
     }

--- a/src/vector_store/lancedb.rs
+++ b/src/vector_store/lancedb.rs
@@ -81,6 +81,8 @@ impl LanceDbBackend {
             ),
             Field::new("chunk_json", DataType::Utf8, false),
             Field::new("file_path", DataType::Utf8, false),
+            Field::new("symbol_kind", DataType::Utf8, false),
+            Field::new("module_path", DataType::Utf8, false),
         ])
     }
 
@@ -107,6 +109,8 @@ impl LanceDbBackend {
             let vector_array = self.create_empty_vector_array();
             let chunk_json_array = StringArray::from(Vec::<String>::new());
             let file_path_array = StringArray::from(Vec::<String>::new());
+            let symbol_kind_array = StringArray::from(Vec::<String>::new());
+            let module_path_array = StringArray::from(Vec::<String>::new());
 
             let batch = RecordBatch::try_new(
                 schema.clone(),
@@ -115,6 +119,8 @@ impl LanceDbBackend {
                     Arc::new(vector_array),
                     Arc::new(chunk_json_array),
                     Arc::new(file_path_array),
+                    Arc::new(symbol_kind_array),
+                    Arc::new(module_path_array),
                 ],
             )
             .map_err(|e| VectorStoreError::backend(format!("Failed to create batch: {}", e)))?;
@@ -129,7 +135,7 @@ impl LanceDbBackend {
 
             tracing::info!("Created LanceDB table: {}", self.table_name);
 
-            // Create BTree index on id column for fast merge_insert lookups
+            // Create BTree indices for fast lookups
             table
                 .create_index(&["id"], Index::BTree(BTreeIndexBuilder::default()))
                 .execute()
@@ -137,8 +143,22 @@ impl LanceDbBackend {
                 .map_err(|e| {
                     VectorStoreError::backend(format!("Failed to create id index: {}", e))
                 })?;
+            table
+                .create_index(&["file_path"], Index::BTree(BTreeIndexBuilder::default()))
+                .execute()
+                .await
+                .map_err(|e| {
+                    VectorStoreError::backend(format!("Failed to create file_path index: {}", e))
+                })?;
+            table
+                .create_index(&["symbol_kind"], Index::BTree(BTreeIndexBuilder::default()))
+                .execute()
+                .await
+                .map_err(|e| {
+                    VectorStoreError::backend(format!("Failed to create symbol_kind index: {}", e))
+                })?;
 
-            tracing::info!("Created BTree index on 'id' column for fast upserts");
+            tracing::info!("Created BTree indices on id, file_path, symbol_kind columns");
         }
 
         Ok(())
@@ -169,6 +189,8 @@ impl LanceDbBackend {
         let mut flat_vectors = Vec::with_capacity(n * self.vector_dim);
         let mut chunk_jsons = Vec::with_capacity(n);
         let mut file_paths = Vec::with_capacity(n);
+        let mut symbol_kinds = Vec::with_capacity(n);
+        let mut module_paths = Vec::with_capacity(n);
 
         // Single pass over all chunks
         for (id, embedding, chunk) in chunks {
@@ -180,6 +202,8 @@ impl LanceDbBackend {
                 })?,
             );
             file_paths.push(chunk.context.file_path.display().to_string());
+            symbol_kinds.push(chunk.context.symbol_kind.clone());
+            module_paths.push(chunk.context.module_path.join("::"));
         }
 
         // Build Arrow arrays from pre-allocated vectors
@@ -193,6 +217,8 @@ impl LanceDbBackend {
                 })?;
         let chunk_json_array = StringArray::from(chunk_jsons);
         let file_path_array = StringArray::from(file_paths);
+        let symbol_kind_array = StringArray::from(symbol_kinds);
+        let module_path_array = StringArray::from(module_paths);
 
         RecordBatch::try_new(
             schema,
@@ -201,6 +227,8 @@ impl LanceDbBackend {
                 Arc::new(vector_array),
                 Arc::new(chunk_json_array),
                 Arc::new(file_path_array),
+                Arc::new(symbol_kind_array),
+                Arc::new(module_path_array),
             ],
         )
         .map_err(|e| VectorStoreError::backend(format!("Failed to create batch: {}", e)))

--- a/tests/test_sync_manager_integration.rs
+++ b/tests/test_sync_manager_integration.rs
@@ -15,7 +15,6 @@ use tempfile::TempDir;
 
 struct SyncTestEnv {
     _temp_dir: TempDir,
-    data_dir: PathBuf,
     codebase1: PathBuf,
     codebase2: PathBuf,
 }
@@ -23,8 +22,6 @@ struct SyncTestEnv {
 impl SyncTestEnv {
     fn new() -> Result<Self> {
         let temp_dir = TempDir::new()?;
-        let data_dir = temp_dir.path().join("data");
-        std::fs::create_dir(&data_dir)?;
 
         let codebase1 = temp_dir.path().join("codebase1");
         let codebase2 = temp_dir.path().join("codebase2");
@@ -34,18 +31,13 @@ impl SyncTestEnv {
 
         Ok(Self {
             _temp_dir: temp_dir,
-            data_dir,
             codebase1,
             codebase2,
         })
     }
 
     fn create_sync_manager(&self, interval_secs: u64) -> SyncManager {
-        SyncManager::new(
-            self.data_dir.join("cache"),
-            self.data_dir.join("index"),
-            interval_secs,
-        )
+        SyncManager::new(interval_secs)
     }
 
     fn write_file(&self, codebase: &PathBuf, name: &str, content: &str) -> Result<PathBuf> {


### PR DESCRIPTION
## Summary

Comprehensive refactoring of the codebase toward production-quality idiomatic Rust, delivered as 4 stacked commits:

- **Dead code cleanup** — removed 6 underscore-prefixed dead items, 4 dead semantic methods, fixed `embed()` sync regression, extracted `EMBEDDING_DIM` constant, added `#![warn(unreachable_pub, dead_code)]`
- **Error types** — `EmbeddingError`, `SearchError`, `IndexingError` with `thiserror`, replacing 8x verbose `Box<dyn Error>` patterns and scattered `anyhow::anyhow!()`
- **Parser API cleanup** — converted `TypeReferenceTracker` to free functions, removed 5 dead re-exports
- **Async pipeline** — wired `embed_async` (`spawn_blocking`) into search hot path, replaced `std::fs` with `tokio::fs` in `read_file_content`
- **RRF unification** — extracted `reciprocal_rank_fusion_core` with parameterized weights, eliminated 64 lines of duplicated algorithm
- **IndexerCore decomposition** — extracted `FileProcessor` (security/filtering/cache) and `EmbeddingBatcher` (memory-aware batch embedding), reducing IndexerCore from god object (7 fields, 14 methods, avg cyclomatic 7.5) to thin 3-field facade (avg cyclomatic 1.0)

## Test plan

- [x] `cargo check` passes (0 errors)
- [x] `cargo test` — 167 passed, 0 failed, 14 ignored (require GPU/model)
- [x] All 9 doc-tests compile
- [x] MCP tool smoke test — all 11 tools return correct results
- [x] Self-healing corruption test — corrupt tantivy index auto-detected, rebuilt, full BM25 scores restored
- [x] New unit tests for `FileProcessor` (5 tests) and `EmbeddingBatcher` (2 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)