### PR TITLE
feat: add rename_symbol tool (preview-only rust-analyzer rename)

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -10,6 +10,7 @@ Complete reference for all MCP tools provided by rust-code-mcp.
 | [`get_similar_code`](#get_similar_code) | Query | Find semantically similar code |
 | [`find_definition`](#find_definition) | Analysis | Locate symbol definitions by name |
 | [`find_references`](#find_references) | Analysis | Find all usages of a symbol by name |
+| [`rename_symbol`](#rename_symbol) | Analysis | Preview renaming a symbol project-wide (no files modified) |
 | [`get_dependencies`](#get_dependencies) | Analysis | List imports for a file |
 | [`get_call_graph`](#get_call_graph) | Analysis | Show function call relationships |
 | [`analyze_complexity`](#analyze_complexity) | Analysis | Calculate code complexity metrics |
@@ -149,6 +150,43 @@ Found 21 reference(s) for 'RustParser':
 /path/to/project/src/indexing/indexer_core.rs:88:13 (reference)
 /path/to/project/src/parser/mod.rs:121:12 (RustParser)
 ...
+```
+
+---
+
+### rename_symbol
+
+Preview a project-wide rename of a Rust symbol using rust-analyzer. **Read-only** — returns the set of edits and file moves that *would* be applied, without modifying any files. Apply the edits yourself if the preview looks correct.
+
+The symbol is resolved by exact name. If multiple symbols share the name, the call fails with an "Ambiguous symbol" error and lists the candidates — disambiguate by using a more specific name. rust-analyzer may also refuse the rename (e.g. for keywords, fields of trait impls in foreign crates, or names that would conflict).
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `symbol_name` | string | Yes | Symbol to rename — must match exactly, ambiguous names are rejected |
+| `new_name` | string | Yes | New name (must be a valid Rust identifier) |
+| `directory` | string | Yes | Project root directory containing Cargo.toml |
+
+**Example:**
+```json
+{
+  "symbol_name": "parse_file",
+  "new_name": "parse_source_file",
+  "directory": "/path/to/project"
+}
+```
+
+**Returns:** A list of text edits (file:start_line:start_col-end_line:end_col → new_text) and any file system moves rust-analyzer would perform (e.g. when renaming a module that owns its own file).
+
+**Example output:**
+```
+Rename preview for 'parse_file' → 'parse_source_file' (no files modified):
+
+Text edits (4):
+  /path/to/project/src/parser/mod.rs:121:12-121:22 → "parse_source_file"
+  /path/to/project/src/parser/mod.rs:148:9-148:19 → "parse_source_file"
+  /path/to/project/src/indexing/indexer_core.rs:64:30-64:40 → "parse_source_file"
+  /path/to/project/src/indexing/indexer_core.rs:88:23-88:33 → "parse_source_file"
 ```
 
 ---

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -2,6 +2,7 @@
 
 mod loader;
 mod position;
+mod rename;
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -12,6 +13,7 @@ use ra_ap_vfs::Vfs;
 use anyhow::Result;
 
 pub use position::Location;
+pub use rename::{RenameEdit, RenameFileMove, RenamePreview};
 
 /// Global semantic service instance (Mutex because AnalysisHost is not Sync)
 pub static SEMANTIC: LazyLock<Mutex<SemanticService>> = LazyLock::new(|| {
@@ -80,5 +82,21 @@ impl SemanticService {
             .ok_or_else(|| anyhow::anyhow!("Project not loaded"))?;
 
         position::find_references_by_name(&ctx.host, &ctx.vfs, symbol_name)
+    }
+
+    /// Preview rename of a symbol by name. Does not modify any files.
+    pub fn rename_by_name(
+        &mut self,
+        project_path: &Path,
+        symbol_name: &str,
+        new_name: &str,
+    ) -> Result<RenamePreview> {
+        self.get_or_load(project_path)?;
+
+        let canonical = project_path.canonicalize()?;
+        let ctx = self.projects.get(&canonical)
+            .ok_or_else(|| anyhow::anyhow!("Project not loaded"))?;
+
+        rename::rename_by_name(&ctx.host, &ctx.vfs, symbol_name, new_name)
     }
 }

--- a/src/semantic/rename.rs
+++ b/src/semantic/rename.rs
@@ -1,0 +1,227 @@
+//! Symbol renaming via rust-analyzer
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use ra_ap_ide::{
+    AnalysisHost, FilePosition, FileSystemEdit, Query, RenameConfig, SourceChange,
+};
+use ra_ap_vfs::Vfs;
+
+/// A single text edit to apply to a file
+#[derive(Debug, Clone)]
+pub struct RenameEdit {
+    pub file_path: PathBuf,
+    pub start_line: u32,
+    pub start_column: u32,
+    pub end_line: u32,
+    pub end_column: u32,
+    pub new_text: String,
+}
+
+impl std::fmt::Display for RenameEdit {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}:{}:{}-{}:{} → {:?}",
+            self.file_path.display(),
+            self.start_line,
+            self.start_column,
+            self.end_line,
+            self.end_column,
+            self.new_text,
+        )
+    }
+}
+
+/// A file move/create as part of a rename (e.g. renaming a module renames a file)
+#[derive(Debug, Clone)]
+pub struct RenameFileMove {
+    pub from: PathBuf,
+    pub to_anchor: PathBuf,
+    pub to_path: String,
+}
+
+impl std::fmt::Display for RenameFileMove {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "move: {} → (anchor: {}) {}",
+            self.from.display(),
+            self.to_anchor.display(),
+            self.to_path,
+        )
+    }
+}
+
+/// Preview of a rename operation
+#[derive(Debug, Clone, Default)]
+pub struct RenamePreview {
+    pub edits: Vec<RenameEdit>,
+    pub file_moves: Vec<RenameFileMove>,
+}
+
+/// Rename the symbol at the given symbol-name. Returns a preview without touching disk.
+///
+/// Resolves the symbol by name first; fails if multiple symbols match (ambiguous rename
+/// is dangerous). Use a fully-qualified name fragment to disambiguate.
+pub fn rename_by_name(
+    host: &AnalysisHost,
+    vfs: &Vfs,
+    symbol_name: &str,
+    new_name: &str,
+) -> Result<RenamePreview> {
+    let analysis = host.analysis();
+
+    let query = Query::new(symbol_name.to_string());
+    let symbols = analysis
+        .symbol_search(query, 50)
+        .context("symbol_search query failed")?;
+
+    if symbols.is_empty() {
+        anyhow::bail!("No symbol found matching '{}'", symbol_name);
+    }
+
+    // Filter to exact name matches to avoid renaming a substring match
+    let exact: Vec<_> = symbols
+        .iter()
+        .filter(|s| s.name.as_str() == symbol_name)
+        .collect();
+
+    let target = match exact.as_slice() {
+        [] => anyhow::bail!(
+            "No exact match for '{}'. Found {} fuzzy candidates.",
+            symbol_name,
+            symbols.len()
+        ),
+        [single] => *single,
+        multiple => {
+            let locs: Vec<String> = multiple
+                .iter()
+                .map(|nav| {
+                    let path = vfs
+                        .file_path(nav.file_id)
+                        .as_path()
+                        .map(|p| p.to_string())
+                        .unwrap_or_else(|| "<virtual>".to_string());
+                    format!("  - {} ({})", path, nav.name)
+                })
+                .collect();
+            anyhow::bail!(
+                "Ambiguous symbol '{}': {} exact matches.\n{}",
+                symbol_name,
+                multiple.len(),
+                locs.join("\n")
+            )
+        }
+    };
+
+    let offset = target.focus_range.unwrap_or(target.full_range).start();
+    let position = FilePosition {
+        file_id: target.file_id,
+        offset,
+    };
+
+    let config = RenameConfig {
+        prefer_no_std: false,
+        prefer_prelude: true,
+        prefer_absolute: false,
+        show_conflicts: true,
+    };
+
+    let source_change: SourceChange = analysis
+        .rename(position, new_name, &config)
+        .context("rename query cancelled")?
+        .map_err(|e| anyhow::anyhow!("rust-analyzer rename refused: {}", e))?;
+
+    source_change_to_preview(vfs, &analysis, source_change)
+}
+
+fn source_change_to_preview(
+    vfs: &Vfs,
+    analysis: &ra_ap_ide::Analysis,
+    change: SourceChange,
+) -> Result<RenamePreview> {
+    let mut preview = RenamePreview::default();
+
+    for (file_id, (text_edit, _snippet)) in &change.source_file_edits {
+        let vfs_path = vfs.file_path(*file_id);
+        let file_path: PathBuf = vfs_path
+            .as_path()
+            .ok_or_else(|| anyhow::anyhow!("Edit refers to non-real path"))?
+            .to_path_buf()
+            .into();
+
+        let line_index = analysis
+            .file_line_index(*file_id)
+            .context("Failed to get line index for edit")?;
+
+        for indel in text_edit.iter() {
+            let start = line_index.line_col(indel.delete.start());
+            let end = line_index.line_col(indel.delete.end());
+            preview.edits.push(RenameEdit {
+                file_path: file_path.clone(),
+                start_line: start.line + 1,
+                start_column: start.col + 1,
+                end_line: end.line + 1,
+                end_column: end.col + 1,
+                new_text: indel.insert.clone(),
+            });
+        }
+    }
+
+    for fs_edit in &change.file_system_edits {
+        match fs_edit {
+            FileSystemEdit::CreateFile { dst, .. } => {
+                let anchor_path = vfs
+                    .file_path(dst.anchor)
+                    .as_path()
+                    .map(|p| p.to_path_buf().into())
+                    .unwrap_or_else(PathBuf::new);
+                preview.file_moves.push(RenameFileMove {
+                    from: PathBuf::new(),
+                    to_anchor: anchor_path,
+                    to_path: dst.path.clone(),
+                });
+            }
+            FileSystemEdit::MoveFile { src, dst } => {
+                let src_path = vfs
+                    .file_path(*src)
+                    .as_path()
+                    .map(|p| p.to_path_buf().into())
+                    .unwrap_or_else(PathBuf::new);
+                let anchor_path = vfs
+                    .file_path(dst.anchor)
+                    .as_path()
+                    .map(|p| p.to_path_buf().into())
+                    .unwrap_or_else(PathBuf::new);
+                preview.file_moves.push(RenameFileMove {
+                    from: src_path,
+                    to_anchor: anchor_path,
+                    to_path: dst.path.clone(),
+                });
+            }
+            FileSystemEdit::MoveDir { src, src_id: _, dst } => {
+                let anchor_path = vfs
+                    .file_path(dst.anchor)
+                    .as_path()
+                    .map(|p| p.to_path_buf().into())
+                    .unwrap_or_else(PathBuf::new);
+                preview.file_moves.push(RenameFileMove {
+                    from: PathBuf::from(src.path.as_str()),
+                    to_anchor: anchor_path,
+                    to_path: dst.path.clone(),
+                });
+            }
+        }
+    }
+
+    preview.edits.sort_by(|a, b| {
+        a.file_path
+            .cmp(&b.file_path)
+            .then(a.start_line.cmp(&b.start_line))
+            .then(a.start_column.cmp(&b.start_column))
+    });
+
+    Ok(preview)
+}

--- a/src/tools/analysis_tools.rs
+++ b/src/tools/analysis_tools.rs
@@ -168,6 +168,53 @@ pub async fn find_references(
     }
 }
 
+/// Preview a rename of a symbol across the project (does not modify files).
+pub async fn rename_symbol(
+    symbol_name: &str,
+    new_name: &str,
+    directory: &str,
+) -> Result<CallToolResult, McpError> {
+    use std::path::Path;
+
+    let project_path = Path::new(directory);
+
+    tracing::debug!("Previewing rename '{}' → '{}'", symbol_name, new_name);
+
+    let preview = SEMANTIC
+        .lock()
+        .map_err(|e| McpError::internal_error(format!("Failed to acquire lock: {}", e), None))?
+        .rename_by_name(project_path, symbol_name, new_name)
+        .map_err(|e| McpError::internal_error(format!("Rename failed: {}", e), None))?;
+
+    if preview.edits.is_empty() && preview.file_moves.is_empty() {
+        return Ok(CallToolResult::success(vec![Content::text(format!(
+            "Rename '{}' → '{}' produced no edits.",
+            symbol_name, new_name
+        ))]));
+    }
+
+    let mut out = format!(
+        "Rename preview for '{}' → '{}' (no files modified):\n\n",
+        symbol_name, new_name
+    );
+
+    if !preview.edits.is_empty() {
+        out.push_str(&format!("Text edits ({}):\n", preview.edits.len()));
+        for edit in &preview.edits {
+            out.push_str(&format!("  {}\n", edit));
+        }
+    }
+
+    if !preview.file_moves.is_empty() {
+        out.push_str(&format!("\nFile system changes ({}):\n", preview.file_moves.len()));
+        for mv in &preview.file_moves {
+            out.push_str(&format!("  {}\n", mv));
+        }
+    }
+
+    Ok(CallToolResult::success(vec![Content::text(out)]))
+}
+
 /// Get dependencies for a file (imports and files that depend on it)
 pub async fn get_dependencies(file_path: &str) -> Result<CallToolResult, McpError> {
     let file_path_obj = Path::new(file_path);
@@ -420,6 +467,12 @@ mod tests {
     #[tokio::test]
     async fn test_analyze_complexity_nonexistent_file() {
         let result = analyze_complexity("/nonexistent/file.rs").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_rename_symbol_invalid_project() {
+        let result = rename_symbol("nonexistent_symbol_xyz", "new_name", "/tmp").await;
         assert!(result.is_err());
     }
 }

--- a/src/tools/search_tool.rs
+++ b/src/tools/search_tool.rs
@@ -46,6 +46,16 @@ pub struct FindReferencesParams {
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct RenameSymbolParams {
+    #[schemars(description = "Symbol name to rename (must match exactly; ambiguous names are rejected)")]
+    pub symbol_name: String,
+    #[schemars(description = "New name for the symbol (valid Rust identifier)")]
+    pub new_name: String,
+    #[schemars(description = "Project root directory containing Cargo.toml")]
+    pub directory: String,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct GetDependenciesParams {
     #[schemars(description = "Path to the file to analyze")]
     pub file_path: String,

--- a/src/tools/search_tool_router.rs
+++ b/src/tools/search_tool_router.rs
@@ -81,7 +81,8 @@ use rmcp::{
 // Re-export parameter types from search_tool for compatibility
 pub use crate::tools::search_tool::{
     AnalyzeComplexityParams, FileContentParams, FindDefinitionParams, FindReferencesParams,
-    GetCallGraphParams, GetDependenciesParams, GetSimilarCodeParams, SearchParams,
+    GetCallGraphParams, GetDependenciesParams, GetSimilarCodeParams, RenameSymbolParams,
+    SearchParams,
 };
 
 /// Main tool router struct
@@ -151,6 +152,19 @@ impl SearchToolRouter {
         }): Parameters<FindReferencesParams>,
     ) -> Result<CallToolResult, McpError> {
         crate::tools::analysis_tools::find_references(&symbol_name, &directory).await
+    }
+
+    /// Preview a rename of a symbol across the project (read-only, no files modified)
+    #[tool(description = "Preview renaming a Rust symbol project-wide using rust-analyzer. Returns the set of edits and file moves WITHOUT modifying any files.")]
+    async fn rename_symbol(
+        &self,
+        Parameters(RenameSymbolParams {
+            symbol_name,
+            new_name,
+            directory,
+        }): Parameters<RenameSymbolParams>,
+    ) -> Result<CallToolResult, McpError> {
+        crate::tools::analysis_tools::rename_symbol(&symbol_name, &new_name, &directory).await
     }
 
     /// Get dependencies for a file (imports and files that depend on it)
@@ -239,7 +253,7 @@ impl ServerHandler for SearchToolRouter {
                 .build(),
             server_info: Implementation::from_build_env(),
             instructions: Some(
-                "This server provides code search and analysis tools: 1) search - keyword search in files, 2) read_file_content - read file contents, 3) find_definition - locate symbol definitions, 4) find_references - find symbol references, 5) get_dependencies - analyze imports, 6) get_call_graph - show function call relationships, 7) analyze_complexity - calculate code metrics, 8) health_check - check system health status, 9) get_similar_code - semantic similarity search, 10) index_codebase - manually index a codebase with incremental change detection, 11) clear_cache - clear corrupted cache/index files to fix MetadataCache errors"
+                "This server provides code search and analysis tools: 1) search - keyword search in files, 2) read_file_content - read file contents, 3) find_definition - locate symbol definitions, 4) find_references - find symbol references, 5) rename_symbol - preview project-wide rename via rust-analyzer (no files written), 6) get_dependencies - analyze imports, 7) get_call_graph - show function call relationships, 8) analyze_complexity - calculate code metrics, 9) health_check - check system health status, 10) get_similar_code - semantic similarity search, 11) index_codebase - manually index a codebase with incremental change detection, 12) clear_cache - clear corrupted cache/index files to fix MetadataCache errors"
                     .into(),
             ),
         }


### PR DESCRIPTION
## Summary
- Wires rust-analyzer's `Analysis::rename` into a new MCP tool `rename_symbol` that returns the full set of edits and file moves a project-wide rename would produce, **without touching disk** — clients (or the LLM) decide whether to apply.
- Resolution is by exact symbol name; ambiguous names are rejected with the list of candidates (silently renaming the wrong symbol is unsafe). `RenameError` from rust-analyzer (keywords, foreign-crate trait items, conflicts) is propagated as an MCP error.
- Apply-on-disk is intentionally out of scope — a future `apply_rename` tool can consume the same preview without risking accidental rewrites from a plain `rename_symbol` call.

### Files
- `src/semantic/rename.rs` — new module; converts `SourceChange` into a flat `RenamePreview` with line/column edits + `file_system_edits`
- `src/semantic/mod.rs` — `SemanticService::rename_by_name`
- `src/tools/analysis_tools.rs` — `rename_symbol()` + smoke test
- `src/tools/search_tool{,_router}.rs` — `RenameSymbolParams` and `#[tool]` registration; updated server-info description
- `TOOLS.md` — documents the new tool, including ambiguity / refusal semantics

## Test plan
- [ ] `cargo test` passes (includes the smoke test in `analysis_tools.rs`)
- [ ] `cargo clippy --all-targets` clean
- [ ] Manual: invoke `rename_symbol` on an unambiguous symbol — preview lists expected edits and file moves
- [ ] Manual: invoke on an ambiguous symbol — call fails and lists candidates
- [ ] Manual: invoke on a keyword / foreign-crate trait item — `RenameError` surfaces cleanly to the client