### PR TITLE
build: make CUDA optional, default to CPU embeddings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3205,6 +3205,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac-sha256"
+version = "1.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
+
+[[package]]
 name = "home"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4820,6 +4826,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lzma-rust2"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1670343e58806300d87950e3401e820b519b9384281bbabfb15e3636689ffd69"
+
+[[package]]
 name = "macro_rules_attribute"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5472,11 +5484,11 @@ version = "2.0.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
 dependencies = [
- "libloading 0.9.0",
  "ndarray 0.17.2",
  "ort-sys",
  "smallvec",
  "tracing",
+ "ureq",
 ]
 
 [[package]]
@@ -5484,6 +5496,11 @@ name = "ort-sys"
 version = "2.0.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
+dependencies = [
+ "hmac-sha256",
+ "lzma-rust2",
+ "ureq",
+]
 
 [[package]]
 name = "ownedbytes"

--- a/crates/rmc-engine/Cargo.toml
+++ b/crates/rmc-engine/Cargo.toml
@@ -15,7 +15,11 @@ embeddings = [
   "dep:futures",
   "dep:toml",
   "fastembed/hf-hub-native-tls",
-  "fastembed/ort-load-dynamic",
+  # Statically link a freshly-downloaded CPU onnxruntime (self-contained binary).
+  # NOT ort-load-dynamic: this machine has no system libonnxruntime.so, and the
+  # stale pyke cache held a CUDA static build whose OrtCreateEnv hangs on AMD
+  # (no NVIDIA driver). download-binaries pulls the CPU build and links it in.
+  "fastembed/ort-download-binaries",
 ]
 embeddings-cuda = [
   "embeddings",

--- a/crates/rmc-indexing/Cargo.toml
+++ b/crates/rmc-indexing/Cargo.toml
@@ -3,9 +3,14 @@ name    = "rmc-indexing"
 version = "0.1.0"
 edition = "2024"
 
+[features]
+# CPU embeddings by default; opt into GPU with `--features cuda` (requires nvcc/CUDA toolkit).
+default = []
+cuda = ["rmc-engine/embeddings-cuda"]
+
 [dependencies]
 # In-workspace dependencies
-rmc-engine = { path = "../rmc-engine", features = ["embeddings-cuda", "vector-store", "hybrid-search"] }
+rmc-engine = { path = "../rmc-engine", features = ["embeddings", "vector-store", "hybrid-search"] }
 rmc-config = { path = "../rmc-config" }
 
 # Search and indexing

--- a/crates/rmc-server/Cargo.toml
+++ b/crates/rmc-server/Cargo.toml
@@ -3,9 +3,14 @@ name    = "rmc-server"
 version = "0.1.0"
 edition = "2024"
 
+[features]
+# CPU embeddings by default; opt into GPU with `--features cuda` (requires nvcc/CUDA toolkit).
+default = []
+cuda = ["rmc-engine/embeddings-cuda", "rmc-indexing/cuda"]
+
 [dependencies]
 # In-workspace dependencies
-rmc-engine   = { path = "../rmc-engine", features = ["embeddings-cuda", "vector-store", "hybrid-search"] }
+rmc-engine   = { path = "../rmc-engine", features = ["embeddings", "vector-store", "hybrid-search"] }
 rmc-graph    = { path = "../rmc-graph", features = ["semantic-embeddings"] }
 rmc-config   = { path = "../rmc-config" }
 rmc-indexing = { path = "../rmc-indexing" }

--- a/crates/rust-code-mcp/Cargo.toml
+++ b/crates/rust-code-mcp/Cargo.toml
@@ -68,3 +68,6 @@ tempfile = "3"
 [features]
 default = ["embedded"]
 embedded = []
+# GPU/CUDA embeddings (qwen3 reranker via candle). Requires nvcc/CUDA toolkit at build time.
+# Default build is CPU-only; opt in with `cargo build --release --features cuda`.
+cuda = ["rmc-server/cuda"]


### PR DESCRIPTION
## Problem

Commit `7b1258a7` ("Isolate CUDA from graph-only builds") hardcoded the `embeddings-cuda` feature into `rmc-indexing` and `rmc-server`. As a result, every default `cargo build --release` pulled in `cudarc` and failed at `nvcc --version` on machines without the CUDA toolkit (including AMD GPUs). Before that commit the build was CPU-only.

## Fix

GPU is opt-in again:
- `rmc-indexing` / `rmc-server` depend on `rmc-engine` with the CPU `embeddings` feature by default.
- Each crate gains a `cuda` feature that re-enables `rmc-engine/embeddings-cuda`, threaded up to the top-level binary (`cuda = ["rmc-server/cuda"]`).

| | command |
|---|---|
| Default (CPU, works everywhere) | `cargo build --release` |
| GPU (requires nvcc) | `cargo build --release --features cuda` |

## Verification

- Default dependency tree no longer contains `cudarc`; `--features cuda` reintroduces it.
- CPU binary boots and logs `CUDA-capable features compiled: false`.

---

## Follow-up: CPU build compiled but **hung at runtime** during indexing

Making the build CPU-only fixed compilation, but the resulting binary still **deadlocked on the first index**: it logged `loading fastembed CPU model` / `Found N Rust files, processing in parallel` and then sat at **~0% CPU with worker threads parked on a futex**, never embedding a single chunk. `clear_cache`, re-downloading the HF model, `HF_HUB_OFFLINE=1`, and pinning CPUs (`taskset`) all made no difference; `ptrace` was blocked by the sandbox so no native stack was available.

**Root cause.** The CPU `embeddings` feature enabled `fastembed/ort-load-dynamic` (= `ort/load-dynamic`) **without** `download-binaries`. In that mode ort links no onnxruntime at build time and instead `dlopen()`s a system `libonnxruntime.so` at runtime. This machine has none — and the only onnxruntime artifacts on disk were a **stale CUDA `download-binaries` cache** (`~/.cache/ort.pyke.io/.../libonnxruntime.a` + `libonnxruntime_providers_cuda.so` / `_tensorrt.so`). So the very first `Session::builder()` (global `OrtCreateEnv`) blocked forever — either failing to locate a usable dynamic lib, or dragging in the CUDA provider which stalls probing for an NVIDIA driver that doesn't exist on AMD.

The hang was localized to `TextEmbedding::try_new` → `Session::builder()` by bisecting with temporary `eprintln` markers (since reverted).

**Fix.** Switch the CPU feature from `ort-load-dynamic` to **`fastembed/ort-download-binaries`** — the same path `embeddings-cuda` already uses via `fastembed/cuda`. ort now downloads the **CPU** onnxruntime and links it **statically**, yielding a self-contained binary that needs no system `libonnxruntime.so` and never touches CUDA.

> ⚠️ Anyone who built an earlier revision must clear the stale CUDA cache before rebuilding, or the wrong onnxruntime is reused:
> ```
> rm -rf ~/.cache/ort.pyke.io
> cargo build --release
> ```

**Verification after fix.** `Session::builder()` + `commit_from_file` succeed (EP count = 0, pure CPU), embedding runs at full multi-core CPU (~1700% CPU, 100+ threads), and a full force-reindex of a ~2.2k-file workspace completes and commits both the BM25 and vector indices. The new pyke cache contains only `libonnxruntime.a` (no CUDA/TensorRT provider `.so`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
