### PR TITLE
feat(server): RMC_EMBEDDING_PROFILE picks the default embedding profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,14 @@ Semantic search and the embedding-backed audits (`get_similar_code`, `similar_to
 
 The default when `embedding_profile` is omitted is `local-cpu-small`. Select another profile by passing `embedding_profile` to `index_codebase` and the search tools. Each profile gets its own independent index, and search must use the profile its index was built with.
 
+**Changing that default takes no recompile** — `RMC_EMBEDDING_PROFILE` names the profile used whenever a call omits `embedding_profile`:
+
+```sh
+RMC_EMBEDDING_PROFILE=local-gpu-small rust-code-mcp
+```
+
+The value is read once at startup, and an unknown name is refused there rather than falling back to the default: a typo must not leave "the GPU profile is on" quietly false, with indexing speed as the only symptom. Two things stay as they are — the profile is part of the index identity, so pointing the default at another profile means a different index that has to be built from scratch; and background sync still skips local CUDA profiles, so a CUDA default leaves the periodic re-index idle while explicit calls keep working.
+
 **API models** (OpenRouter) require an API key in the environment — keys are never read from config files:
 
 ```sh

--- a/crates/rmc-server/src/mcp/defaults.rs
+++ b/crates/rmc-server/src/mcp/defaults.rs
@@ -1,10 +1,25 @@
 //! Operational defaults for MCP server startup and automatic work.
 
 use rmc_engine::embeddings::{EmbeddingBackend, EmbeddingRuntime};
+use std::sync::OnceLock;
 
 pub const BACKGROUND_SYNC_ENV: &str = "RMC_BACKGROUND_SYNC";
 pub const BACKGROUND_SYNC_ENABLED_VALUES: &str = "1/true/yes/on";
-pub const AUTOMATIC_EMBEDDING_PROFILE: &str = "local-cpu-small";
+
+/// Profile the server embeds with when the caller names none of its own.
+///
+/// The default is CPU: it is always compiled in and runs on any machine. GPU
+/// profiles need both a build feature (`--features cuda`) and a working local
+/// runtime, so they are opted into EXPLICITLY through [`EMBEDDING_PROFILE_ENV`]
+/// rather than guessed from what happens to be installed.
+pub const DEFAULT_AUTOMATIC_EMBEDDING_PROFILE: &str = "local-cpu-small";
+
+/// Knob that picks the default profile: `RMC_EMBEDDING_PROFILE=local-gpu-small`.
+///
+/// ⚠ The profile is part of the embedder identity, and that identity is part of
+/// the collection path: switching profiles means a DIFFERENT index, which has to
+/// be built from scratch.
+pub const EMBEDDING_PROFILE_ENV: &str = "RMC_EMBEDDING_PROFILE";
 
 pub fn parse_background_sync_env(value: Option<&str>) -> bool {
     let Some(value) = value else {
@@ -17,13 +32,49 @@ pub fn parse_background_sync_env(value: Option<&str>) -> bool {
     )
 }
 
+/// Name of the default profile: from [`EMBEDDING_PROFILE_ENV`], else
+/// [`DEFAULT_AUTOMATIC_EMBEDDING_PROFILE`].
+///
+/// Read ONCE per process: the default profile is a property of the server run,
+/// not of an individual request, and it must not change mid-flight (otherwise
+/// half an index would arrive from one embedder and half from another).
 pub fn automatic_embedding_profile_name() -> &'static str {
-    AUTOMATIC_EMBEDDING_PROFILE
+    static PROFILE: OnceLock<String> = OnceLock::new();
+    PROFILE
+        .get_or_init(|| {
+            let requested = resolve_automatic_profile_name(
+                std::env::var(EMBEDDING_PROFILE_ENV).ok().as_deref(),
+            );
+
+            // Fail-fast: a typo in the profile name must not silently fall back
+            // to the CPU default — "the GPU profile is on" would then be false,
+            // and the only symptom would be indexing speed.
+            if let Err(err) = EmbeddingBackend::from_profile_name(&requested) {
+                panic!(
+                    "{EMBEDDING_PROFILE_ENV}='{requested}' is not a usable embedding profile: {err}"
+                );
+            }
+            requested
+        })
+        .as_str()
+}
+
+/// Parses the [`EMBEDDING_PROFILE_ENV`] value into a profile name.
+///
+/// An empty or whitespace-only value counts as "variable not set": a blank value
+/// in a launch wrapper is an ordinary slip, and taking it as a profile name would
+/// refuse to start the server instead of using a sensible default.
+pub(crate) fn resolve_automatic_profile_name(env_value: Option<&str>) -> String {
+    env_value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(DEFAULT_AUTOMATIC_EMBEDDING_PROFILE)
+        .to_string()
 }
 
 pub(crate) fn automatic_embedding_backend() -> EmbeddingBackend {
-    EmbeddingBackend::from_profile_name(AUTOMATIC_EMBEDDING_PROFILE)
-        .expect("built-in automatic embedding profile exists")
+    EmbeddingBackend::from_profile_name(automatic_embedding_profile_name())
+        .expect("automatic embedding profile is validated on first read")
 }
 
 pub fn cuda_capable_features_compiled() -> bool {
@@ -58,10 +109,49 @@ mod tests {
     }
 
     #[test]
-    fn automatic_embedding_backend_is_cpu_profile() {
-        let backend = automatic_embedding_backend();
+    fn profile_env_absent_or_blank_falls_back_to_cpu_default() {
+        assert_eq!(resolve_automatic_profile_name(None), "local-cpu-small");
+        assert_eq!(resolve_automatic_profile_name(Some("")), "local-cpu-small");
+        assert_eq!(
+            resolve_automatic_profile_name(Some("   ")),
+            "local-cpu-small"
+        );
+    }
+
+    #[test]
+    fn profile_env_selects_the_named_profile() {
+        assert_eq!(
+            resolve_automatic_profile_name(Some("local-gpu-small")),
+            "local-gpu-small"
+        );
+        // Surrounding whitespace comes from launch wrappers, it is not part of
+        // the name.
+        assert_eq!(
+            resolve_automatic_profile_name(Some(" local-gpu-small\n")),
+            "local-gpu-small"
+        );
+    }
+
+    /// The default profile has to be one that is always compiled in and fit for
+    /// background work: the server starts with it on any machine.
+    #[test]
+    fn default_profile_is_a_cpu_background_capable_backend() {
+        let backend = EmbeddingBackend::from_profile_name(DEFAULT_AUTOMATIC_EMBEDDING_PROFILE)
+            .expect("default profile resolves");
 
         assert_eq!(backend.profile.name(), "local-cpu-small");
         assert!(is_background_embedding_backend(&backend));
+    }
+
+    /// A name that is not among the profiles must be REJECTED rather than
+    /// silently falling back to the CPU default.
+    #[test]
+    fn unknown_profile_name_is_rejected() {
+        let requested = resolve_automatic_profile_name(Some("local-gpu-small-typo"));
+
+        assert!(
+            EmbeddingBackend::from_profile_name(&requested).is_err(),
+            "a typo in the profile name must not resolve"
+        );
     }
 }

--- a/crates/rust-code-mcp/src/main.rs
+++ b/crates/rust-code-mcp/src/main.rs
@@ -7,6 +7,7 @@
 use rmc_server::mcp::{
     automatic_embedding_profile_name, cuda_capable_features_compiled,
     parse_background_sync_env, ServerRuntime, BACKGROUND_SYNC_ENABLED_VALUES, BACKGROUND_SYNC_ENV,
+    EMBEDDING_PROFILE_ENV,
 };
 use rmc_server::tools::SearchTool;
 use rmcp::{ServiceExt, transport::stdio};
@@ -40,12 +41,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let background_sync_env = std::env::var(BACKGROUND_SYNC_ENV).ok();
     let background_sync_enabled = parse_background_sync_env(background_sync_env.as_deref());
     tracing::info!(
-        "MCP startup defaults: background sync {} ({}='{}'; enabled only for {}, case-insensitive); automatic/background embedding profile default {}; CUDA-capable features compiled: {}",
+        "MCP startup defaults: background sync {} ({}='{}'; enabled only for {}, case-insensitive); automatic/background embedding profile default {} (set {} to change it); CUDA-capable features compiled: {}",
         if background_sync_enabled { "enabled" } else { "disabled" },
         BACKGROUND_SYNC_ENV,
         background_sync_env.as_deref().unwrap_or("<unset>"),
         BACKGROUND_SYNC_ENABLED_VALUES,
         automatic_embedding_profile_name(),
+        EMBEDDING_PROFILE_ENV,
         cuda_capable_features_compiled(),
     );
 


### PR DESCRIPTION
Makes the server's default embedding profile a runtime knob instead of a compiled-in constant.

### Why

`AUTOMATIC_EMBEDDING_PROFILE` decided which profile the server uses for every call that omits `embedding_profile` (and for the automatic work). Pointing the server at another profile therefore meant editing the constant and rebuilding — even though the profile registry itself is already runtime data (built-ins plus `embedding_profiles.toml`).

### What changes

- `RMC_EMBEDDING_PROFILE=<profile>` selects the default profile; unset keeps today's behaviour (`local-cpu-small`), so this is not a behaviour change for existing users.
- **Unknown name is refused at startup**, not silently replaced by the CPU default. A typo would otherwise leave "the GPU profile is on" false with indexing speed as the only symptom. The message names the offending value and lists the known profiles.
- Blank / whitespace-only is treated as "not set" — an empty value from a launch wrapper is an ordinary slip and should not refuse to start; surrounding whitespace is trimmed for the same reason.
- Read **once per process** via `OnceLock`: the default profile is a property of the run, not of a request. Flipping it mid-flight would mean half an index from one embedder and half from another.
- Parsing is a pure `resolve_automatic_profile_name(Option<&str>)`, so the tests do not depend on the environment of the test process.
- The startup log now prints the variable name next to the effective profile, so the knob is discoverable where the other startup defaults are already logged.
- README: a short paragraph in **Embedding Models**, including the two things that do *not* change — the profile is part of the index identity (a different default means a different index to build), and background sync still skips local CUDA profiles.

### Verification

`cargo test -p rmc-server` — the 5 new/updated tests in `mcp::defaults` pass (default when unset/blank, selection by name, whitespace trimming, typo rejected, default profile still background-capable).

Live probe on the built binary, since a test cannot cover the startup panic path:

| run | result |
|---|---|
| `RMC_EMBEDDING_PROFILE=local-cpu-small-typo` | exit **101**, `not a usable embedding profile: … expected one of: local-gpu-small, local-cpu-small, openrouter-qwen3-8b, local-qwen3-4b, local-qwen3-8b` |
| unset | logs `embedding profile default local-cpu-small (set RMC_EMBEDDING_PROFILE to change it)` |
| `' local-cpu-small '` | same as unset — trimmed |
| `openrouter-qwen3-8b` | logs `embedding profile default openrouter-qwen3-8b` |

### Note, unrelated to this PR

On current `main`, `cargo check --workspace --all-targets` is red before this change: `tests/test_burn_performance.rs` and `tests/test_index_tool_integration.rs` still call `index_codebase(params, None)` while the function takes four arguments. Happy to send that as a separate PR if useful.

Also, `tools::graph::tests::default_snapshot_graph_round_trips_with_crate_types_and_crate_skeleton` fails on `main` here (it asserts a `load` re-export in a listing that the default `limit = 50` truncates at 91 total bindings) — the test reads the repository it is built in, so its outcome moves with the tree. Not touched by this PR.
