### PR TITLE
feat(server): one shared daemon instead of a server per session

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7334,6 +7334,7 @@ dependencies = [
  "anyhow",
  "bincode 1.3.3",
  "directories",
+ "fs2",
  "glob",
  "num_cpus",
  "rayon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4560,6 +4560,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4928,6 +4937,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -7343,6 +7361,8 @@ dependencies = [
  "anyhow",
  "directories",
  "heed",
+ "libc",
+ "libmimalloc-sys",
  "num_cpus",
  "ra_ap_ide",
  "ra_ap_ide_db",
@@ -7446,6 +7466,7 @@ dependencies = [
  "heed",
  "hf-hub",
  "lancedb",
+ "mimalloc",
  "notify 6.1.1",
  "num_cpus",
  "ra_ap_base_db",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7440,6 +7440,7 @@ dependencies = [
  "cargo_metadata",
  "directories",
  "fastembed",
+ "fs2",
  "futures",
  "glob",
  "heed",

--- a/README.md
+++ b/README.md
@@ -224,13 +224,33 @@ to. Six knobs do that instead, all in seconds or MB, all with `0` meaning *off*:
 | `RMC_GC_INTERVAL_SECS` | 300 | How often loaded analyses are garbage-collected. This is also what makes salsa's LRU capacities do anything: they only evict while the revision bumps, and a project nobody edits never bumps on its own. |
 | `RMC_RSS_SOFT_MB` | 12288 | RSS above which the daemon unloads *all* contexts (at most one unload per `RMC_RSS_COOLDOWN_SECS`, default 300). Sized for the three workspaces above: ~2.3 GB of fixed startup cost plus ~3 GB each. |
 | `RMC_MIN_AVAILABLE_MB` | 6144 | Machine-wide floor on `MemAvailable`: below it the daemon unloads even though its own RSS is fine. The only reading here that sees pressure the daemon did not cause — a build, a second analyser, the application under development — and the caches belong to whoever needs the memory more. It never retires the daemon; that pressure usually passes with the build that caused it. |
-| `RMC_RSS_HARD_MB` | 20480 | RSS above which unloading is judged hopeless: the daemon unlinks its socket so new clients start a fresh one, and finishes serving the clients it has. |
+| `RMC_RSS_HARD_MB` | 28672 | RSS above which unloading is judged hopeless: the daemon unlinks its socket so new clients start a fresh one, unloads its contexts on that same tick, and finishes serving the clients it has. Sized above the measured 15–21 GB working range of one `Full` context — at 20480 it retired a *healthy* daemon three times in two hours. |
 | `RMC_RETIRE_GRACE_SECS` | 1800 | How long a retired daemon waits for those clients before exiting anyway. It has to end: a client session runs for hours, and a retired daemon holding 24 GB next to its successor is the failure this bounds. Exiting on the deadline **drops those connections** — the affected session loses its MCP tools until restarted. |
 
 The first two keep the working set from growing; the rest are the guard for when it
 grows anyway. Note which question each asks: three of them ask "is this process too
 big?", and `RMC_MIN_AVAILABLE_MB` asks "does the machine still have room?" — a daemon
 can answer the first comfortably while the machine around it goes to swap.
+
+The cooldown does not apply to a retired daemon's *first* unload. Retirement changes the
+economics of unloading rather than its nature: that daemon takes no new clients and its
+successor is already loading its own context, so it must not sit on 20+ GB waiting out a
+countdown that was armed for a different situation.
+
+### Keeping the index honest when the disk fills
+
+| Knob | Default | What it does |
+|---|---:|---|
+| `RMC_MIN_INDEX_FREE_MB` | 2048 | Refuse persistent index writes below this much free space, checked before a run, before each file and before every batch. `0` disables the guard. |
+
+The failure this prevents is not "indexing stops" but "indexing stops and says it
+finished": an `ENOSPC` mid-run used to leave a *complete* Merkle snapshot behind, so
+every later background sync compared the tree against it and found nothing to do, while
+the files whose writes had failed stayed missing from the vector store. The snapshot now
+keeps the previous node for every path whose write failed — the retry falls out of the
+comparison itself — and it is written to a temporary file and renamed rather than
+truncating the last good one. `index_codebase` reports `⚠ Partially indexed` with the
+number of retryable failures instead of a checkmark.
 
 ## Embedding Models
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,38 @@ For Rust-specific workspace analysis, first call `build_hypergraph` once (reuses
 
 Index data is stored in `~/Library/Application Support/dev.rust-code-mcp.search/` (macOS) or `~/.local/share/search/` (Linux), keyed by a hash of the project path **and the active embedding profile** — so different profiles get independent indexes. It does not write index/cache data to your project directory; `crate_skeleton` is the explicit exception and writes generated files under `.skeleton/`. The persisted hypergraph lives alongside the index data (under `graph/<workspace_hash>/`, in LMDB). `clear_cache` with `include_hypergraph=true` wipes both.
 
+## Shared daemon (one server per project)
+
+The stdio transport is 1:1 with its client by construction: every editor window or
+agent session spawns its own server process — and with it another copy of the loaded
+rust-analyzer context (~2 GB per workspace) plus another ONNX/GPU context. Measured on
+one developer machine before this landed: six live servers, 8.9 GB, all analyzing the
+same repository.
+
+The runtime state was already shareable (`RuntimeState` is a bundle of `Arc`s, semantic
+contexts are cached per project path, and locking is per workspace), so the only missing
+piece was a transport that accepts more than one client:
+
+- running the binary **with no arguments** makes it a *client* of a per-project daemon,
+  spawning that daemon on first use — no change to `.mcp.json` is needed;
+- the daemon serves every connection from one shared `RuntimeState` and exits after
+  30 minutes with no clients (`--idle-secs` / `RMC_DAEMON_IDLE_SECS`, `0` = never);
+- if the daemon cannot be reached or started, the client serves the session in-process,
+  exactly as before — the daemon is a memory optimisation, not a new point of failure.
+
+The socket key covers the project directory, the binary's size/mtime, and the env vars
+that change what the server computes. A rebuilt binary therefore gets its own daemon
+instead of silently attaching to one that answers differently.
+
+```bash
+rust-code-mcp --print-socket   # which socket this project resolves to
+rust-code-mcp --in-process     # previous behaviour (same as RMC_DAEMON=0)
+rust-code-mcp --daemon         # run the daemon in the foreground
+```
+
+Sockets and daemon logs live in `$XDG_RUNTIME_DIR/rust-code-mcp/` (override with
+`RMC_DAEMON_DIR`). Unix only; on other platforms the server stays in-process.
+
 ## Embedding Models
 
 Semantic search and the embedding-backed audits (`get_similar_code`, `similar_to_item`, `semantic_overlaps`) run on a configurable embedding **profile**. Built-in profiles:

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ For Rust-specific workspace analysis, first call `build_hypergraph` once (reuses
 
 Index data is stored in `~/Library/Application Support/dev.rust-code-mcp.search/` (macOS) or `~/.local/share/search/` (Linux), keyed by a hash of the project path **and the active embedding profile** — so different profiles get independent indexes. It does not write index/cache data to your project directory; `crate_skeleton` is the explicit exception and writes generated files under `.skeleton/`. The persisted hypergraph lives alongside the index data (under `graph/<workspace_hash>/`, in LMDB). `clear_cache` with `include_hypergraph=true` wipes both.
 
-## Shared daemon (one server per project)
+## Shared daemon (one server per user)
 
 The stdio transport is 1:1 with its client by construction: every editor window or
 agent session spawns its own server process — and with it another copy of the loaded

--- a/README.md
+++ b/README.md
@@ -196,6 +196,22 @@ rust-code-mcp --daemon         # run the daemon in the foreground
 Sockets and daemon logs live in `$XDG_RUNTIME_DIR/rust-code-mcp/` (override with
 `RMC_DAEMON_DIR`). Unix only; on other platforms the server stays in-process.
 
+### Keeping the daemon's memory bounded
+
+A daemon outlives its clients by design, so nothing bounds it the way a session used
+to. Five knobs do that instead, all in seconds or MB, all with `0` meaning *off*:
+
+| Knob | Default | What it does |
+|---|---:|---|
+| `RMC_MAX_PROJECTS` | 2 | How many rust-analyzer contexts stay loaded. Past the cap, the least recently used one is dropped; the project being queried is never the victim. |
+| `RMC_GC_INTERVAL_SECS` | 300 | How often loaded analyses are garbage-collected. This is also what makes salsa's LRU capacities do anything: they only evict while the revision bumps, and a project nobody edits never bumps on its own. |
+| `RMC_RSS_SOFT_MB` | 8192 | RSS above which the daemon unloads *all* contexts (at most one unload per `RMC_RSS_COOLDOWN_SECS`, default 300). |
+| `RMC_RSS_HARD_MB` | 16384 | RSS above which unloading is judged hopeless: the daemon unlinks its socket so new clients start a fresh one, and finishes serving the clients it has. |
+| `RMC_RETIRE_GRACE_SECS` | 1800 | How long a retired daemon waits for those clients before exiting anyway. It has to end: a client session runs for hours, and a retired daemon holding 24 GB next to its successor is the failure this bounds. Exiting on the deadline **drops those connections** — the affected session loses its MCP tools until restarted. |
+
+The first two keep the working set from growing; the last three are the guard for when
+it grows anyway.
+
 ## Embedding Models
 
 Semantic search and the embedding-backed audits (`get_similar_code`, `similar_to_item`, `semantic_overlaps`) run on a configurable embedding **profile**. Built-in profiles:

--- a/README.md
+++ b/README.md
@@ -176,41 +176,61 @@ The runtime state was already shareable (`RuntimeState` is a bundle of `Arc`s, s
 contexts are cached per project path, and locking is per workspace), so the only missing
 piece was a transport that accepts more than one client:
 
-- running the binary **with no arguments** makes it a *client* of a per-project daemon,
-  spawning that daemon on first use — no change to `.mcp.json` is needed;
+- running the binary **with no arguments** makes it a *client* of a shared daemon,
+  spawning that daemon on first use — no config change needed in `.mcp.json`;
 - the daemon serves every connection from one shared `RuntimeState` and exits after
   30 minutes with no clients (`--idle-secs` / `RMC_DAEMON_IDLE_SECS`, `0` = never);
 - if the daemon cannot be reached or started, the client serves the session in-process,
   exactly as before — the daemon is a memory optimisation, not a new point of failure.
 
-The socket key covers the project directory, the binary's size/mtime, and the env vars
-that change what the server computes. A rebuilt binary therefore gets its own daemon
-instead of silently attaching to one that answers differently.
+The socket key covers the binary's size/mtime and the env vars that change what the
+server computes (`RMC_EMBEDDING_PROFILE`, `RMC_BACKGROUND_SYNC`). A
+rebuilt binary or a different profile therefore gets its own daemon instead of silently
+attaching to one that answers differently.
+
+**One daemon serves every working directory.** The key deliberately excludes the
+directory a session starts in. It used to include it, and the result was one daemon per
+directory: measured on one machine, 11 processes holding 12.5 GB between them, several
+analysing the same repository. The cwd never selected the project in the first place —
+every tool takes its `directory` as a parameter — so keying on it bought no isolation,
+only duplication.
+
+The consequence for callers: **path parameters must be absolute**. The daemon shares no
+working directory with the session asking, so a relative path is refused rather than
+resolved against a directory nobody chose (which would answer about the wrong tree
+without saying so).
 
 ```bash
-rust-code-mcp --print-socket   # which socket this project resolves to
-rust-code-mcp --in-process     # previous behaviour (same as RMC_DAEMON=0)
+rust-code-mcp --print-socket   # which socket this configuration resolves to
+rust-code-mcp --in-process     # old behaviour (same as RMC_DAEMON=0)
 rust-code-mcp --daemon         # run the daemon in the foreground
 ```
 
-Sockets and daemon logs live in `$XDG_RUNTIME_DIR/rust-code-mcp/` (override with
-`RMC_DAEMON_DIR`). Unix only; on other platforms the server stays in-process.
+Sockets and daemon logs live in `$XDG_RUNTIME_DIR/rust-code-mcp/`, falling back to
+`/run/user/<uid>/rust-code-mcp/` when that variable is unset (a session started outside a
+login shell) and to `/tmp/rust-code-mcp-$USER/` when there is no runtime directory at
+all; override with `RMC_DAEMON_DIR`. The fallback order matters: computing the same key
+but looking for it in a different directory is another way to end up with two daemons.
+Unix only; on other platforms the server stays in-process.
 
 ### Keeping the daemon's memory bounded
 
 A daemon outlives its clients by design, so nothing bounds it the way a session used
-to. Five knobs do that instead, all in seconds or MB, all with `0` meaning *off*:
+to. Six knobs do that instead, all in seconds or MB, all with `0` meaning *off*:
 
 | Knob | Default | What it does |
 |---|---:|---|
-| `RMC_MAX_PROJECTS` | 2 | How many rust-analyzer contexts stay loaded. Past the cap, the least recently used one is dropped; the project being queried is never the victim. |
+| `RMC_MAX_PROJECTS` | 3 | How many rust-analyzer contexts stay loaded. Past the cap, the least recently used one is dropped; the project being queried is never the victim. |
 | `RMC_GC_INTERVAL_SECS` | 300 | How often loaded analyses are garbage-collected. This is also what makes salsa's LRU capacities do anything: they only evict while the revision bumps, and a project nobody edits never bumps on its own. |
-| `RMC_RSS_SOFT_MB` | 8192 | RSS above which the daemon unloads *all* contexts (at most one unload per `RMC_RSS_COOLDOWN_SECS`, default 300). |
-| `RMC_RSS_HARD_MB` | 16384 | RSS above which unloading is judged hopeless: the daemon unlinks its socket so new clients start a fresh one, and finishes serving the clients it has. |
+| `RMC_RSS_SOFT_MB` | 12288 | RSS above which the daemon unloads *all* contexts (at most one unload per `RMC_RSS_COOLDOWN_SECS`, default 300). Sized for the three workspaces above: ~2.3 GB of fixed startup cost plus ~3 GB each. |
+| `RMC_MIN_AVAILABLE_MB` | 6144 | Machine-wide floor on `MemAvailable`: below it the daemon unloads even though its own RSS is fine. The only reading here that sees pressure the daemon did not cause — a build, a second analyser, the application under development — and the caches belong to whoever needs the memory more. It never retires the daemon; that pressure usually passes with the build that caused it. |
+| `RMC_RSS_HARD_MB` | 20480 | RSS above which unloading is judged hopeless: the daemon unlinks its socket so new clients start a fresh one, and finishes serving the clients it has. |
 | `RMC_RETIRE_GRACE_SECS` | 1800 | How long a retired daemon waits for those clients before exiting anyway. It has to end: a client session runs for hours, and a retired daemon holding 24 GB next to its successor is the failure this bounds. Exiting on the deadline **drops those connections** — the affected session loses its MCP tools until restarted. |
 
-The first two keep the working set from growing; the last three are the guard for when
-it grows anyway.
+The first two keep the working set from growing; the rest are the guard for when it
+grows anyway. Note which question each asks: three of them ask "is this process too
+big?", and `RMC_MIN_AVAILABLE_MB` asks "does the machine still have room?" — a daemon
+can answer the first comfortably while the machine around it goes to swap.
 
 ## Embedding Models
 

--- a/crates/rmc-engine/Cargo.toml
+++ b/crates/rmc-engine/Cargo.toml
@@ -14,6 +14,9 @@ embeddings = [
   "dep:tokio",
   "dep:futures",
   "dep:toml",
+  # Model weights are cached under the user's cache dir rather than the process's
+  # working directory — see `model_cache_dir` in `embeddings::fastembed_cpu`.
+  "dep:directories",
   "fastembed/hf-hub-native-tls",
   # Use ORT at build/link time instead of dlopening libonnxruntime.so at runtime.
   # Plain Cargo builds download the CPU ORT archive; Nix builds override this

--- a/crates/rmc-engine/src/embeddings/fastembed_cpu.rs
+++ b/crates/rmc-engine/src/embeddings/fastembed_cpu.rs
@@ -6,6 +6,22 @@ use crate::embeddings::{Embedding, EmbeddingError};
 use fastembed::{EmbeddingModel, TextEmbedding, TextInitOptions};
 use std::sync::Mutex;
 
+/// Where downloaded model weights live.
+///
+/// fastembed's own default is `.fastembed_cache` **relative to the process's
+/// working directory**, which puts a copy of the weights in whatever tree a
+/// session happened to start in — four of them, 128–279 MB each, had piled up
+/// on one machine before this was fixed. One daemon now serves every working
+/// directory, so that default would make the location of the weights depend on
+/// which session woke the daemon first.
+fn model_cache_dir() -> Result<std::path::PathBuf, EmbeddingError> {
+    directories::ProjectDirs::from("", "", "rust-code-mcp")
+        .map(|d| d.cache_dir().join("models"))
+        .ok_or_else(|| {
+            EmbeddingError::model_init("cannot resolve a cache directory for model weights")
+        })
+}
+
 pub(super) struct FastembedCpuEmbedder {
     inner: Mutex<TextEmbedding>,
     backend: EmbeddingBackend,
@@ -32,6 +48,7 @@ impl FastembedCpuEmbedder {
 
         let options = TextInitOptions::new(to_fastembed_model(model))
             .with_max_length(backend.max_len)
+            .with_cache_dir(model_cache_dir()?)
             .with_show_download_progress(false);
         let inner = TextEmbedding::try_new(options)
             .map_err(|e| EmbeddingError::model_init(e.to_string()))?;

--- a/crates/rmc-graph/src/graph/loader.rs
+++ b/crates/rmc-graph/src/graph/loader.rs
@@ -151,7 +151,16 @@ fn load_crate_target_kinds(
 ) -> (HashMap<String, String>, HashMap<String, String>) {
     let manifest_path = workspace_root.join("Cargo.toml");
     let mut command = MetadataCommand::new();
-    command.manifest_path(manifest_path).no_deps();
+    // `current_dir` is not cosmetic: rustup picks the toolchain by the working
+    // directory (not by `--manifest-path`), and cargo walks up from it looking
+    // for `.cargo/config.toml`. Without this the daemon would analyse every
+    // workspace under the toolchain and registries of whatever tree it was
+    // started in. rust-analyzer sets it on every subprocess it spawns; this was
+    // the one place in the tree that did not.
+    command
+        .current_dir(workspace_root)
+        .manifest_path(manifest_path)
+        .no_deps();
     let metadata = match command.exec() {
         Ok(metadata) => metadata,
         Err(error) => {

--- a/crates/rmc-indexing/Cargo.toml
+++ b/crates/rmc-indexing/Cargo.toml
@@ -56,6 +56,7 @@ bincode = { workspace = true }
 
 # Cross-platform config/data directories (used by snapshot path resolver)
 directories = { workspace = true }
+fs2 = "0.4"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/rmc-indexing/src/indexing/incremental.rs
+++ b/crates/rmc-indexing/src/indexing/incremental.rs
@@ -9,13 +9,15 @@
 //!
 //! This achieves 100-1000x speedup vs full reindexing for unchanged codebases.
 
-use rmc_engine::embeddings::EmbeddingBackend;
 use crate::indexing::identity::{
     active_chunking_identity_for_backend, identity_hash, indexing_identity,
 };
 use crate::indexing::merkle::{ChangeSet, FileSystemMerkle};
-use crate::indexing::unified::{IndexFileResult, IndexStats, UnifiedIndexer};
+use crate::indexing::unified::{
+    IndexFileResult, IndexStats, UnifiedIndexer, ensure_index_disk_headroom,
+};
 use anyhow::Result;
+use rmc_engine::embeddings::EmbeddingBackend;
 use std::path::{Path, PathBuf};
 use tracing;
 
@@ -163,6 +165,7 @@ impl IncrementalIndexer {
             "Starting incremental indexing for {}",
             codebase_path.display()
         );
+        ensure_index_disk_headroom(&self.config.cache_path)?;
 
         let snapshot_path = get_snapshot_path_for_backend(codebase_path, &self.config.backend);
         tracing::debug!("Snapshot path: {}", snapshot_path.display());
@@ -189,7 +192,7 @@ impl IncrementalIndexer {
         tracing::info!("Built Merkle tree with {} files", new_merkle.file_count());
 
         // Step 3: Determine indexing strategy
-        let stats = if let Some(old) = old_merkle {
+        let stats = if let Some(old) = old_merkle.as_ref() {
             // Incremental: compare trees and index only changes
             self.incremental_update(codebase_path, &old, &new_merkle)
                 .await?
@@ -202,11 +205,16 @@ impl IncrementalIndexer {
                 .await?
         };
 
-        // Step 4: Save new snapshot for next time
-        new_merkle.save_snapshot(&snapshot_path)?;
+        // Step 4: commit only the paths whose index writes completed. Failed
+        // additions stay absent and failed modifications/deletions retain the
+        // old hash, so the next background tick retries them automatically.
+        let committed_merkle =
+            new_merkle.snapshot_with_retries(old_merkle.as_ref(), &stats.retry_files);
+        committed_merkle.save_snapshot(&snapshot_path)?;
         tracing::info!(
-            "Saved new Merkle snapshot to {}",
-            snapshot_path.display()
+            "Saved Merkle snapshot to {} ({} retryable file failure(s) retained)",
+            snapshot_path.display(),
+            stats.failed_files,
         );
 
         Ok(stats)
@@ -261,12 +269,27 @@ impl IncrementalIndexer {
         changes: ChangeSet,
     ) -> Result<IndexStats> {
         let mut stats = IndexStats::default();
+        let storage_path = self.config.cache_path.clone();
         let indexer = self.ensure_indexer().await?;
 
         // Handle deletions
         for deleted_path in &changes.deleted {
-            tracing::info!("Deleting chunks for removed file: {}", deleted_path.display());
-            indexer.delete_file_chunks(deleted_path).await?;
+            ensure_index_disk_headroom(&storage_path)?;
+            tracing::info!(
+                "Deleting chunks for removed file: {}",
+                deleted_path.display()
+            );
+            if let Err(error) = indexer.delete_file_chunks(deleted_path).await {
+                stats.failed_files += 1;
+                stats.retry_files.push(deleted_path.clone());
+                tracing::warn!(
+                    "Failed to delete {} from the index (will retry): {}",
+                    deleted_path.display(),
+                    error
+                );
+                continue;
+            }
+
             stats.skipped_files += 1;
         }
 
@@ -274,17 +297,25 @@ impl IncrementalIndexer {
         for modified_path in &changes.modified {
             tracing::info!("Reindexing modified file: {}", modified_path.display());
             // Delete old chunks first
-            indexer.delete_file_chunks(modified_path).await?;
+            if let Err(error) = indexer.delete_file_chunks(modified_path).await {
+                stats.failed_files += 1;
+                stats.retry_files.push(modified_path.clone());
+                tracing::warn!(
+                    "Failed to clear old chunks for {} (will retry): {}",
+                    modified_path.display(),
+                    error
+                );
+                continue;
+            }
 
-            match indexer.index_file(modified_path).await {
+            match indexer.reindex_file(modified_path).await {
                 Ok(IndexFileResult::Indexed { chunks_count }) => {
                     stats.indexed_files += 1;
                     stats.total_chunks += chunks_count;
                 }
                 Ok(_) => stats.skipped_files += 1,
                 Err(e) => {
-                    tracing::error!("Failed to index {}: {}", modified_path.display(), e);
-                    stats.skipped_files += 1;
+                    stats.record_error(modified_path, &e);
                 }
             }
         }
@@ -300,8 +331,7 @@ impl IncrementalIndexer {
                 }
                 Ok(_) => stats.skipped_files += 1,
                 Err(e) => {
-                    tracing::error!("Failed to index {}: {}", added_path.display(), e);
-                    stats.skipped_files += 1;
+                    stats.record_error(added_path, &e);
                 }
             }
         }
@@ -310,9 +340,10 @@ impl IncrementalIndexer {
         indexer.commit()?;
 
         tracing::info!(
-            "✓ Incremental update complete: {} files indexed, {} chunks",
+            "✓ Incremental update complete: {} files indexed, {} chunks, {} retryable failures",
             stats.indexed_files,
-            stats.total_chunks
+            stats.total_chunks,
+            stats.failed_files,
         );
 
         Ok(stats)
@@ -362,16 +393,8 @@ mod tests {
     fn snapshot_path_changes_by_chunking_identity() {
         let codebase_path = Path::new("/tmp/rust-code-mcp-snapshot-test");
         let backend = EmbeddingBackend::default();
-        let first = indexing_identity(
-            codebase_path,
-            &backend,
-            "chunk-split:v1:target768:hard1024",
-        );
-        let second = indexing_identity(
-            codebase_path,
-            &backend,
-            "chunk-split:v1:target512:hard768",
-        );
+        let first = indexing_identity(codebase_path, &backend, "chunk-split:v1:target768:hard1024");
+        let second = indexing_identity(codebase_path, &backend, "chunk-split:v1:target512:hard768");
 
         assert_ne!(
             get_snapshot_path_for_identity(&first),

--- a/crates/rmc-indexing/src/indexing/merkle.rs
+++ b/crates/rmc-indexing/src/indexing/merkle.rs
@@ -10,6 +10,7 @@ use rs_merkle::{Hasher, MerkleTree};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 use walkdir::WalkDir;
@@ -82,6 +83,25 @@ pub struct FileSystemMerkle {
 }
 
 impl FileSystemMerkle {
+    fn from_nodes(mut file_to_node: HashMap<PathBuf, FileNode>, snapshot_version: u64) -> Self {
+        let mut paths: Vec<PathBuf> = file_to_node.keys().cloned().collect();
+        paths.sort();
+        let mut hashes = Vec::with_capacity(paths.len());
+        for (leaf_index, path) in paths.iter().enumerate() {
+            let node = file_to_node
+                .get_mut(path)
+                .expect("path came from the same node map");
+            node.leaf_index = leaf_index;
+            hashes.push(node.content_hash);
+        }
+
+        Self {
+            tree: MerkleTree::<Sha256Hasher>::from_leaves(&hashes),
+            file_to_node,
+            snapshot_version,
+        }
+    }
+
     /// Build a Merkle tree from a directory
     ///
     /// This scans all Rust files in the directory and creates a Merkle tree
@@ -221,6 +241,31 @@ impl FileSystemMerkle {
         }
     }
 
+    /// Build the snapshot that is safe to commit after a partial indexing run.
+    ///
+    /// Successful paths keep their new hashes. A retryable modification or
+    /// deletion retains its previous node, while a retryable addition is left
+    /// absent. Consequently the next comparison presents exactly those paths
+    /// as changed again instead of declaring a failed write up to date.
+    pub(crate) fn snapshot_with_retries(
+        &self,
+        previous: Option<&Self>,
+        retry_paths: &[PathBuf],
+    ) -> Self {
+        let mut nodes = self.file_to_node.clone();
+        for path in retry_paths {
+            match previous.and_then(|snapshot| snapshot.file_to_node.get(path)) {
+                Some(old_node) => {
+                    nodes.insert(path.clone(), old_node.clone());
+                }
+                None => {
+                    nodes.remove(path);
+                }
+            }
+        }
+        Self::from_nodes(nodes, self.snapshot_version)
+    }
+
     /// Save snapshot to disk
     pub fn save_snapshot(&self, path: &Path) -> Result<()> {
         let snapshot = MerkleSnapshot {
@@ -235,8 +280,30 @@ impl FileSystemMerkle {
             std::fs::create_dir_all(parent)?;
         }
 
-        let file = std::fs::File::create(path)?;
-        bincode::serialize_into(file, &snapshot)?;
+        // Never truncate the last good snapshot in place. An ENOSPC while
+        // serializing used to turn a recoverable partial indexing run into a
+        // corrupt snapshot that every later background tick failed to load.
+        let temporary = path.with_extension(format!("tmp-{}", std::process::id()));
+        let write_result = (|| -> Result<()> {
+            let mut file = std::fs::File::create(&temporary)?;
+            bincode::serialize_into(&mut file, &snapshot)?;
+            file.flush()?;
+            file.sync_all()?;
+
+            #[cfg(windows)]
+            if path.exists() {
+                // Windows rename does not replace an existing destination.
+                // The complete temporary file is already durable, so ENOSPC
+                // cannot destroy the previous snapshot before this point.
+                std::fs::remove_file(path)?;
+            }
+            std::fs::rename(&temporary, path)?;
+            Ok(())
+        })();
+        if let Err(error) = write_result {
+            let _ = std::fs::remove_file(&temporary);
+            return Err(error);
+        }
 
         tracing::info!(
             "Saved Merkle snapshot v{} to {}",
@@ -411,6 +478,33 @@ mod tests {
     }
 
     #[test]
+    fn partial_snapshot_retries_failed_add_modify_and_delete() {
+        let temp_dir = TempDir::new().unwrap();
+        let modified = temp_dir.path().join("modified.rs");
+        let deleted = temp_dir.path().join("deleted.rs");
+        let added = temp_dir.path().join("added.rs");
+
+        std::fs::write(&modified, "fn value() -> u8 { 1 }").unwrap();
+        std::fs::write(&deleted, "fn old() {}").unwrap();
+        let old = FileSystemMerkle::from_directory(temp_dir.path()).unwrap();
+
+        std::fs::write(&modified, "fn value() -> u8 { 2 }").unwrap();
+        std::fs::remove_file(&deleted).unwrap();
+        std::fs::write(&added, "fn new() {}").unwrap();
+        let current = FileSystemMerkle::from_directory(temp_dir.path()).unwrap();
+
+        let committed = current.snapshot_with_retries(
+            Some(&old),
+            &[modified.clone(), deleted.clone(), added.clone()],
+        );
+        let retry = current.detect_changes(&committed);
+
+        assert_eq!(retry.modified, vec![modified]);
+        assert_eq!(retry.deleted, vec![deleted]);
+        assert_eq!(retry.added, vec![added]);
+    }
+
+    #[test]
     fn test_snapshot_save_and_load() {
         let temp_dir = TempDir::new().unwrap();
         let test_file = temp_dir.path().join("test.rs");
@@ -430,6 +524,33 @@ mod tests {
         assert_eq!(merkle1.file_count(), merkle2.file_count());
         assert_eq!(merkle1.root_hash(), merkle2.root_hash());
         assert!(!merkle1.has_changes(&merkle2));
+    }
+
+    #[test]
+    fn snapshot_replacement_keeps_a_loadable_complete_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let source = temp_dir.path().join("source.rs");
+        let snapshot_path = temp_dir.path().join("merkle.snapshot");
+
+        std::fs::write(&source, "fn first() {}").unwrap();
+        FileSystemMerkle::from_directory(temp_dir.path())
+            .unwrap()
+            .save_snapshot(&snapshot_path)
+            .unwrap();
+
+        std::fs::write(&source, "fn second() {}").unwrap();
+        let expected = FileSystemMerkle::from_directory(temp_dir.path()).unwrap();
+        expected.save_snapshot(&snapshot_path).unwrap();
+
+        let loaded = FileSystemMerkle::load_snapshot(&snapshot_path)
+            .unwrap()
+            .unwrap();
+        assert_eq!(loaded.root_hash(), expected.root_hash());
+        assert!(
+            !snapshot_path
+                .with_extension(format!("tmp-{}", std::process::id()))
+                .exists()
+        );
     }
 
     #[test]

--- a/crates/rmc-indexing/src/indexing/mod.rs
+++ b/crates/rmc-indexing/src/indexing/mod.rs
@@ -15,6 +15,7 @@ pub mod project_paths;
 mod retry;
 pub mod search;
 mod tantivy_adapter;
+mod traversal;
 mod unified;
 mod unified_parallel;
 
@@ -30,4 +31,5 @@ pub use project_paths::{
 };
 pub use search::open_bm25_search;
 pub use tantivy_adapter::TantivyAdapter;
+pub use traversal::collect_project_rust_files;
 pub use unified::{IndexFileResult, IndexStats, UnifiedIndexer};

--- a/crates/rmc-indexing/src/indexing/project_paths.rs
+++ b/crates/rmc-indexing/src/indexing/project_paths.rs
@@ -202,9 +202,19 @@ impl IndexingProjectPaths {
     }
 }
 
+/// Hash a project directory into the key its cache/index/collection live under.
+///
+/// Canonicalized first, the way `indexing_identity` already does. Two spellings
+/// of one directory — a symlinked path and its target — used to get two
+/// separate indexes, and once one daemon started serving every working
+/// directory the same asymmetry meant two clients could land on one key by
+/// spelling a path the same *relative* way. Canonicalization can fail (the
+/// directory may not exist yet); the raw path is then the only thing there is.
 pub fn dir_hash(dir: &Path) -> String {
+    let canonical = std::fs::canonicalize(dir);
+    let keyed = canonical.as_deref().unwrap_or(dir);
     let mut hasher = Sha256::new();
-    hasher.update(dir.to_string_lossy().as_bytes());
+    hasher.update(keyed.to_string_lossy().as_bytes());
     format!("{:x}", hasher.finalize())
 }
 
@@ -248,6 +258,39 @@ pub fn read_embedder_identity(vector_path: &Path) -> Result<Option<String>, Stri
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    /// Two spellings of one directory must share one index. They did not: this
+    /// hash was taken from the literal string while `indexing_identity` already
+    /// canonicalized, so a symlinked path and its target indexed separately —
+    /// and once one daemon started serving every working directory, the same
+    /// asymmetry let two clients spelling a path the same *relative* way land on
+    /// one key.
+    ///
+    /// Mutation that must fail it: hash `dir` instead of its canonical form.
+    #[test]
+    fn a_symlinked_directory_hashes_like_its_target() {
+        let real = TempDir::new().unwrap();
+        let parent = TempDir::new().unwrap();
+        let link = parent.path().join("link");
+        std::os::unix::fs::symlink(real.path(), &link).unwrap();
+
+        assert_eq!(
+            dir_hash(&link),
+            dir_hash(real.path()),
+            "a symlink and its target are one project and must share one index"
+        );
+    }
+
+    /// A path that does not exist cannot be canonicalized, and must still hash
+    /// to something stable rather than panicking or collapsing to a constant.
+    #[test]
+    fn a_missing_directory_still_hashes_to_itself() {
+        let missing = Path::new("/nonexistent-project-for-tests");
+        let other = Path::new("/nonexistent-project-for-tests-2");
+
+        assert_eq!(dir_hash(missing), dir_hash(missing));
+        assert_ne!(dir_hash(missing), dir_hash(other));
+    }
 
     fn backend(name: &str) -> EmbeddingBackend {
         EmbeddingBackend::from_profile_name(name).unwrap()

--- a/crates/rmc-indexing/src/indexing/traversal.rs
+++ b/crates/rmc-indexing/src/indexing/traversal.rs
@@ -1,0 +1,80 @@
+//! Single source of truth for "which `*.rs` files belong to a project".
+//!
+//! The walk used to live inside `unified_parallel::collect_rust_files`, where
+//! it was reachable only by the indexer. A daemon that keeps a rust-analyzer
+//! context loaded across sessions needs the same answer for a different
+//! question — "did anything in this project change while it sat idle?" — and
+//! two independent walkers would mean the two sides disagree about what a
+//! project file is, which shows up as a context that is either refreshed for no
+//! reason or not refreshed when it should be.
+
+use std::path::{Path, PathBuf};
+use walkdir::WalkDir;
+
+/// Directories never descended into: build output, vendored copies, VCS
+/// metadata and generated skeleton trees. Sources under these are either not
+/// ours or not authoritative.
+pub(crate) const SKIPPED_DIRS: [&str; 6] =
+    ["target", "vendor", ".git", ".jj", ".direnv", ".skeleton"];
+
+/// True when a directory with this name must not be descended into.
+pub(crate) fn is_skipped_dir_name(name: &str) -> bool {
+    SKIPPED_DIRS.contains(&name)
+}
+
+/// Walk `root` and return every reachable `*.rs` file outside
+/// [`SKIPPED_DIRS`], plus the number of entries that could not be read.
+///
+/// Unreadable entries are counted rather than fatal: a single permission error
+/// must not make the whole tree unindexable. The caller decides whether to
+/// warn — both call sites do.
+pub fn collect_project_rust_files(root: &Path) -> (Vec<PathBuf>, usize) {
+    let mut rust_files = Vec::new();
+    let mut walk_errors = 0;
+
+    let walker = WalkDir::new(root).into_iter().filter_entry(|entry| {
+        !(entry.file_type().is_dir() && is_skipped_dir_name(&entry.file_name().to_string_lossy()))
+    });
+
+    for entry in walker {
+        match entry {
+            Ok(e)
+                if e.file_type().is_file()
+                    && e.path().extension() == Some(std::ffi::OsStr::new("rs")) =>
+            {
+                rust_files.push(e.path().to_path_buf());
+            }
+            Ok(_) => {}
+            Err(err) => {
+                let path = err.path().unwrap_or_else(|| Path::new("<unknown>"));
+                tracing::warn!("Failed to access {}: {}", path.display(), err);
+                walk_errors += 1;
+            }
+        }
+    }
+
+    (rust_files, walk_errors)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn skips_build_and_generated_trees() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let root = temp_dir.path();
+        for dir in ["src", "target/debug", "vendor/foo/src", ".skeleton/src"] {
+            fs::create_dir_all(root.join(dir)).expect("create dir");
+            fs::write(root.join(dir).join("lib.rs"), "pub fn f() {}\n").expect("write");
+        }
+
+        let (files, errors) = collect_project_rust_files(root);
+
+        assert_eq!(errors, 0);
+        assert_eq!(files.len(), 1, "only src/lib.rs is a project file: {files:?}");
+        assert!(files[0].ends_with("src/lib.rs"));
+    }
+}

--- a/crates/rmc-indexing/src/indexing/unified.rs
+++ b/crates/rmc-indexing/src/indexing/unified.rs
@@ -5,19 +5,20 @@
 //! - VectorStore: Vector indexing operations (LanceDB embedded backend)
 //! - IndexerCore: Core file processing and embedding generation
 
-use rmc_engine::chunker::{ChunkId, CodeChunk};
-use rmc_config::config::IndexerConfig;
-use rmc_engine::embeddings::{EmbeddingBackend, EmbeddingGenerator};
-use rmc_engine::search::Bm25Search;
+use crate::indexing::error_collection::{ErrorCategory, categorize_error};
 use crate::indexing::indexer_core::IndexerCore;
 use crate::indexing::tantivy_adapter::TantivyAdapter;
 use crate::indexing::unified_parallel::{
     collect_rust_files, parallel_parse_batch, process_batch_errors,
 };
 use crate::metrics::IndexingMetrics;
-use rmc_engine::vector_store::VectorStore;
 use anyhow::{Context, Result};
-use std::path::Path;
+use rmc_config::config::IndexerConfig;
+use rmc_engine::chunker::{ChunkId, CodeChunk};
+use rmc_engine::embeddings::{EmbeddingBackend, EmbeddingGenerator};
+use rmc_engine::search::Bm25Search;
+use rmc_engine::vector_store::VectorStore;
+use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 use tantivy::Index;
 
@@ -28,10 +29,15 @@ pub struct IndexStats {
     pub total_files: usize,
     /// Number of files that were indexed
     pub indexed_files: usize,
-    /// Number of files skipped (unchanged)
+    /// Number of unchanged files skipped through the metadata cache.
     pub unchanged_files: usize,
-    /// Number of files that failed to index
+    /// Number of files intentionally skipped or removed.
     pub skipped_files: usize,
+    /// Number of transient failures that must be retried.
+    pub failed_files: usize,
+    /// Paths that the Merkle snapshot must leave at their previous state.
+    #[doc(hidden)]
+    pub retry_files: Vec<PathBuf>,
     /// Total number of chunks generated
     pub total_chunks: usize,
 }
@@ -40,6 +46,20 @@ impl IndexStats {
     /// Create stats indicating no changes
     pub fn unchanged() -> Self {
         Self::default()
+    }
+
+    pub(crate) fn record_error(&mut self, file_path: &Path, error: &anyhow::Error) {
+        match categorize_error(error.as_ref()) {
+            ErrorCategory::Permanent => {
+                tracing::debug!("Skipped {}: {}", file_path.display(), error);
+                self.skipped_files += 1;
+            }
+            ErrorCategory::Transient => {
+                tracing::warn!("Failed {} (will retry): {}", file_path.display(), error);
+                self.failed_files += 1;
+                self.retry_files.push(file_path.to_path_buf());
+            }
+        }
     }
 }
 
@@ -68,6 +88,53 @@ pub struct UnifiedIndexer {
     /// callers (e.g. cache-version checks) that need to reconcile
     /// against the model that built this index.
     backend: EmbeddingBackend,
+    /// Existing path on the filesystem that stores the persistent indexes.
+    storage_root: PathBuf,
+}
+
+const MIN_INDEX_FREE_ENV: &str = "RMC_MIN_INDEX_FREE_MB";
+const DEFAULT_MIN_INDEX_FREE_MB: u64 = 2048;
+
+fn configured_min_index_free_mb() -> u64 {
+    std::env::var(MIN_INDEX_FREE_ENV)
+        .ok()
+        .and_then(|value| value.trim().parse().ok())
+        .unwrap_or(DEFAULT_MIN_INDEX_FREE_MB)
+}
+
+fn has_disk_headroom(available_bytes: u64, minimum_mb: u64) -> bool {
+    minimum_mb == 0 || available_bytes >= minimum_mb.saturating_mul(1024 * 1024)
+}
+
+fn nearest_existing_path(path: &Path) -> &Path {
+    let mut candidate = path;
+    while !candidate.exists() {
+        let Some(parent) = candidate.parent() else {
+            break;
+        };
+        candidate = parent;
+    }
+    candidate
+}
+
+pub(crate) fn ensure_index_disk_headroom(path: &Path) -> Result<()> {
+    let minimum_mb = configured_min_index_free_mb();
+    if minimum_mb == 0 {
+        return Ok(());
+    }
+    let probe = nearest_existing_path(path);
+    let available = fs2::available_space(probe)
+        .with_context(|| format!("Failed to read free space at {}", probe.display()))?;
+    if !has_disk_headroom(available, minimum_mb) {
+        anyhow::bail!(
+            "index write refused: {} MiB free at {}, below {}={} MiB; free disk space or set the threshold to 0 to disable",
+            available / (1024 * 1024),
+            probe.display(),
+            MIN_INDEX_FREE_ENV,
+            minimum_mb,
+        );
+    }
+    Ok(())
 }
 
 impl UnifiedIndexer {
@@ -142,7 +209,7 @@ impl UnifiedIndexer {
             .join("vectors")
             .join(collection_name);
         let vector_store =
-            VectorStore::new_embedded(vector_path, vector_size, embedder_identity)
+            VectorStore::new_embedded(vector_path.clone(), vector_size, embedder_identity)
                 .await
                 .map_err(|e| anyhow::anyhow!("Failed to initialize VectorStore: {}", e))?;
 
@@ -154,6 +221,7 @@ impl UnifiedIndexer {
             vector_store,
             metrics: IndexingMetrics::new(),
             backend,
+            storage_root: vector_path,
         })
     }
 
@@ -164,6 +232,25 @@ impl UnifiedIndexer {
 
     /// Index a single file to both Tantivy and vector store
     pub async fn index_file(&mut self, file_path: &Path) -> Result<IndexFileResult> {
+        self.index_file_impl(file_path, true).await
+    }
+
+    /// Reindex a path that the Merkle tree proved was modified.
+    ///
+    /// This deliberately bypasses the metadata-cache fast path. If a previous
+    /// multi-file run wrote this file successfully but failed before committing
+    /// its Merkle snapshot, the cache already describes the new bytes. The next
+    /// run still has to rebuild after deleting the path's old chunks.
+    pub(crate) async fn reindex_file(&mut self, file_path: &Path) -> Result<IndexFileResult> {
+        self.index_file_impl(file_path, false).await
+    }
+
+    async fn index_file_impl(
+        &mut self,
+        file_path: &Path,
+        consult_metadata_cache: bool,
+    ) -> Result<IndexFileResult> {
+        ensure_index_disk_headroom(&self.storage_root)?;
         let file_start = Instant::now();
 
         // Check if file should be processed
@@ -172,9 +259,11 @@ impl UnifiedIndexer {
         }
 
         // Fast stat-based change detection (avoids reading file content)
-        if !self.core.has_stat_changed(file_path)? {
-            tracing::debug!("File unchanged (stat): {}", file_path.display());
-            return Ok(IndexFileResult::Unchanged);
+        if consult_metadata_cache {
+            if !self.core.has_stat_changed(file_path)? {
+                tracing::debug!("File unchanged (stat): {}", file_path.display());
+                return Ok(IndexFileResult::Unchanged);
+            }
         }
 
         // Read file content (only if stat suggests change)
@@ -182,7 +271,7 @@ impl UnifiedIndexer {
             .context(format!("Failed to read file: {}", file_path.display()))?;
 
         // Content hash check (confirms stat-based detection)
-        if !self.core.has_file_changed(file_path, &content)? {
+        if consult_metadata_cache && !self.core.has_file_changed(file_path, &content)? {
             tracing::debug!("File unchanged (hash): {}", file_path.display());
             return Ok(IndexFileResult::Unchanged);
         }
@@ -222,7 +311,9 @@ impl UnifiedIndexer {
             .zip(embeddings.into_iter())
             .map(|(chunk, embedding)| (chunk.id, embedding, chunk))
             .collect();
-        self.vector_store.upsert_chunks(chunk_data).await
+        self.vector_store
+            .upsert_chunks(chunk_data)
+            .await
             .map_err(|e| anyhow::anyhow!("Failed to index chunks to vector store: {}", e))?;
 
         // Update metadata cache
@@ -232,11 +323,14 @@ impl UnifiedIndexer {
         let file_duration = file_start.elapsed();
         self.metrics.file_latencies.push(file_duration);
 
-        self.core.refresh_memory_monitor()?;
-        self.metrics.peak_memory_bytes = self
-            .metrics
-            .peak_memory_bytes
-            .max(self.core.memory_used_bytes()?);
+        // Persistence is complete at this point. A best-effort metrics probe
+        // must not turn that success into an indexing failure: a retry of a
+        // modification deletes its chunks before consulting the metadata cache.
+        if let Err(error) = self.core.refresh_memory_monitor() {
+            tracing::warn!("Could not refresh indexing memory metrics: {error}");
+        } else if let Ok(memory_used) = self.core.memory_used_bytes() {
+            self.metrics.peak_memory_bytes = self.metrics.peak_memory_bytes.max(memory_used);
+        }
 
         tracing::info!(
             "✓ Indexed {} chunks from {} in {:?}",
@@ -263,7 +357,11 @@ impl UnifiedIndexer {
             return Ok(stats);
         }
 
-        tracing::info!("Found {} Rust files in {}", rust_files.len(), dir_path.display());
+        tracing::info!(
+            "Found {} Rust files in {}",
+            rust_files.len(),
+            dir_path.display()
+        );
 
         // Index each file
         for file in rust_files {
@@ -279,24 +377,26 @@ impl UnifiedIndexer {
                     stats.skipped_files += 1;
                 }
                 Err(e) => {
-                    tracing::error!("Failed to index {}: {}", file.display(), e);
-                    stats.skipped_files += 1;
+                    stats.record_error(&file, &e);
                 }
             }
         }
 
         // Commit Tantivy changes
-        self.tantivy.commit().context("Failed to commit Tantivy index")?;
+        self.tantivy
+            .commit()
+            .context("Failed to commit Tantivy index")?;
 
         // Finalize metrics
         self.finalize_metrics(&stats, total_start.elapsed());
 
         tracing::info!(
-            "✓ Indexing complete: {} files indexed, {} chunks, {} unchanged, {} skipped",
+            "✓ Indexing complete: {} files indexed, {} chunks, {} unchanged, {} skipped, {} failed",
             stats.indexed_files,
             stats.total_chunks,
             stats.unchanged_files,
-            stats.skipped_files
+            stats.skipped_files,
+            stats.failed_files
         );
 
         Ok(stats)
@@ -348,7 +448,10 @@ impl UnifiedIndexer {
             return Ok(stats);
         }
 
-        tracing::info!("Found {} Rust files, processing in parallel", rust_files.len());
+        tracing::info!(
+            "Found {} Rust files, processing in parallel",
+            rust_files.len()
+        );
 
         // Calculate safe batch size
         let batch_size = self.core.calculate_safe_batch_size()?;
@@ -356,6 +459,7 @@ impl UnifiedIndexer {
 
         // Process in batches
         for (batch_idx, file_batch) in rust_files.chunks(batch_size).enumerate() {
+            ensure_index_disk_headroom(&self.storage_root)?;
             tracing::info!(
                 "Processing batch {}/{} ({} files)",
                 batch_idx + 1,
@@ -403,10 +507,11 @@ impl UnifiedIndexer {
         self.finalize_metrics(&stats, total_start.elapsed());
 
         tracing::info!(
-            "✓ Parallel indexing complete: {} files indexed, {} chunks, {} skipped",
+            "✓ Parallel indexing complete: {} files indexed, {} chunks, {} skipped, {} failed",
             stats.indexed_files,
             stats.total_chunks,
-            stats.skipped_files
+            stats.skipped_files,
+            stats.failed_files
         );
 
         Ok(stats)
@@ -416,7 +521,9 @@ impl UnifiedIndexer {
     pub async fn delete_file_chunks(&mut self, file_path: &Path) -> Result<()> {
         self.tantivy.delete_file_chunks(file_path)?;
         let file_path_str = file_path.to_string_lossy().to_string();
-        self.vector_store.delete_by_file_path(&file_path_str).await
+        self.vector_store
+            .delete_by_file_path(&file_path_str)
+            .await
             .map_err(|e| anyhow::anyhow!("Failed to delete chunks from vector store: {}", e))?;
         tracing::debug!("Deleted chunks for file: {}", file_path.display());
         Ok(())
@@ -438,7 +545,9 @@ impl UnifiedIndexer {
         self.tantivy.commit()?;
         tracing::info!("✓ Cleared Tantivy index");
 
-        self.vector_store.clear_collection().await
+        self.vector_store
+            .clear_collection()
+            .await
             .map_err(|e| anyhow::anyhow!("Failed to clear vector store: {}", e))?;
         tracing::info!("✓ Cleared vector store");
 
@@ -502,10 +611,7 @@ impl UnifiedIndexer {
         );
 
         // Generate embeddings in GPU-optimized batches
-        let all_embeddings = self
-            .core
-            .generate_embeddings_batched(&all_chunks)
-            .await?;
+        let all_embeddings = self.core.generate_embeddings_batched(&all_chunks).await?;
 
         let embed_duration = embed_start.elapsed();
         self.metrics.embed_duration += embed_duration;
@@ -533,7 +639,10 @@ impl UnifiedIndexer {
             .collect();
 
         // Single batched upsert to vector store (instead of N calls)
-        tracing::debug!("Upserting {} chunks to vector store...", all_chunk_data.len());
+        tracing::debug!(
+            "Upserting {} chunks to vector store...",
+            all_chunk_data.len()
+        );
         self.vector_store
             .upsert_chunks(all_chunk_data)
             .await
@@ -593,6 +702,25 @@ impl Drop for UnifiedIndexer {
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    #[test]
+    fn disk_headroom_guard_is_inclusive_and_can_be_disabled() {
+        let mib = 1024 * 1024;
+        assert!(!has_disk_headroom(2047 * mib, 2048));
+        assert!(has_disk_headroom(2048 * mib, 2048));
+        assert!(has_disk_headroom(0, 0));
+    }
+
+    #[test]
+    fn transient_file_errors_are_reported_for_retry() {
+        let mut stats = IndexStats::default();
+        let path = Path::new("/workspace/src/lib.rs");
+        stats.record_error(path, &anyhow::anyhow!("No space left on device"));
+
+        assert_eq!(stats.failed_files, 1);
+        assert_eq!(stats.skipped_files, 0);
+        assert_eq!(stats.retry_files, vec![path.to_path_buf()]);
+    }
 
     #[tokio::test]
     #[ignore] // Requires embedding model

--- a/crates/rmc-indexing/src/indexing/unified_parallel.rs
+++ b/crates/rmc-indexing/src/indexing/unified_parallel.rs
@@ -99,12 +99,8 @@ pub(super) fn parallel_parse_batch(
     (processed, error_collector)
 }
 
-/// Drain `error_collector` into `stats.skipped_files`, logging each entry
-/// at the appropriate level for its category.
-pub(super) fn process_batch_errors(
-    error_collector: &ErrorCollector,
-    stats: &mut IndexStats,
-) {
+/// Drain parse errors into permanent skips and retryable failures.
+pub(super) fn process_batch_errors(error_collector: &ErrorCollector, stats: &mut IndexStats) {
     for error in error_collector.get_errors() {
         match error.category {
             crate::indexing::error_collection::ErrorCategory::Permanent => {
@@ -112,8 +108,13 @@ pub(super) fn process_batch_errors(
                 stats.skipped_files += 1;
             }
             crate::indexing::error_collection::ErrorCategory::Transient => {
-                tracing::warn!("Failed {}: {}", error.file_path.display(), error.message);
-                stats.skipped_files += 1;
+                tracing::warn!(
+                    "Failed {} (will retry): {}",
+                    error.file_path.display(),
+                    error.message
+                );
+                stats.failed_files += 1;
+                stats.retry_files.push(error.file_path);
             }
         }
     }

--- a/crates/rmc-indexing/src/indexing/unified_parallel.rs
+++ b/crates/rmc-indexing/src/indexing/unified_parallel.rs
@@ -8,11 +8,11 @@
 
 use crate::indexing::error_collection::{categorize_error, ErrorCollector, ErrorDetail};
 use crate::indexing::indexer_core::{IndexerCore, ProcessedFile};
+use crate::indexing::traversal::collect_project_rust_files;
 use crate::indexing::unified::IndexStats;
 use anyhow::Result;
 use rayon::prelude::*;
 use std::path::{Path, PathBuf};
-use walkdir::WalkDir;
 
 /// Walk `dir_path` and return all reachable `*.rs` files, skipping common
 /// VCS / build / generated directories (`target`, `vendor`, `.git`, `.jj`,
@@ -24,36 +24,7 @@ pub(super) fn collect_rust_files(
     dir_path: &Path,
     stats: &mut IndexStats,
 ) -> Result<Vec<PathBuf>> {
-    let mut rust_files = Vec::new();
-    let mut walk_errors = 0;
-
-    let walker = WalkDir::new(dir_path)
-        .into_iter()
-        .filter_entry(|entry| {
-            let name = entry.file_name().to_string_lossy();
-            !(entry.file_type().is_dir()
-                && matches!(
-                    name.as_ref(),
-                    "target" | "vendor" | ".git" | ".jj" | ".direnv" | ".skeleton"
-                ))
-        });
-
-    for entry in walker {
-        match entry {
-            Ok(e)
-                if e.file_type().is_file()
-                    && e.path().extension() == Some(std::ffi::OsStr::new("rs")) =>
-            {
-                rust_files.push(e.path().to_path_buf());
-            }
-            Ok(_) => {}
-            Err(err) => {
-                let path = err.path().unwrap_or_else(|| Path::new("<unknown>"));
-                tracing::warn!("Failed to access {}: {}", path.display(), err);
-                walk_errors += 1;
-            }
-        }
-    }
+    let (rust_files, walk_errors) = collect_project_rust_files(dir_path);
 
     if walk_errors > 0 {
         tracing::warn!(

--- a/crates/rmc-server/Cargo.toml
+++ b/crates/rmc-server/Cargo.toml
@@ -7,6 +7,11 @@ edition = "2024"
 # CPU embeddings by default; opt into GPU with `--features cuda` (requires nvcc/CUDA toolkit).
 default = []
 cuda = ["rmc-engine/embeddings-cuda", "rmc-indexing/cuda"]
+# The same switch as the binary's: when the global allocator is mimalloc,
+# returning memory has to go through `mi_collect` rather than glibc's
+# `malloc_trim` — that one would trim a foreign, nearly empty heap and look
+# like a broken knob.
+mimalloc = ["dep:libmimalloc-sys"]
 
 [dependencies]
 # In-workspace dependencies
@@ -47,6 +52,16 @@ ra_ap_ide_db        = { workspace = true }
 "ra_ap_load-cargo"  = { workspace = true }
 ra_ap_project_model = { workspace = true }
 ra_ap_vfs           = { workspace = true }
+
+# Returning free memory to the kernel: `malloc_trim` on glibc builds.
+[target.'cfg(all(target_os = "linux", target_env = "gnu"))'.dependencies]
+libc = "0.2"
+
+# The same, for when the allocator has been swapped for mimalloc — see the
+# `mimalloc` feature.
+[dependencies.libmimalloc-sys]
+version = "0.1"
+optional = true
 
 [dev-dependencies]
 ra_ap_syntax = { workspace = true }

--- a/crates/rmc-server/src/deep_stack.rs
+++ b/crates/rmc-server/src/deep_stack.rs
@@ -1,10 +1,12 @@
 //! Running rust-analyzer work on a stack deep enough for it.
 //!
-//! Every graph tool here loads a workspace through rust-analyzer and then walks
-//! HIR/AST trees recursively. That recursion is bounded by the *shape of the
-//! analyzed source*, not by anything we control, and it does not fit in the
-//! 2 MiB stack a tokio blocking-pool thread gets by default: building the
-//! hypergraph for this very workspace aborted the process with
+//! Work that loads a workspace through rust-analyzer walks HIR/AST trees
+//! recursively — the graph tools building a hypergraph, the audits, and the
+//! interner sweep inside a garbage collection alike. That recursion is bounded
+//! by the *shape of the analyzed source*, not by anything we control, and it
+//! does not fit in the 2 MiB stack a tokio blocking-pool thread gets by
+//! default: building the hypergraph for this very workspace aborted the
+//! process with
 //!
 //! ```text
 //! thread 'tokio-rt-worker' has overflowed its stack

--- a/crates/rmc-server/src/lib.rs
+++ b/crates/rmc-server/src/lib.rs
@@ -3,7 +3,8 @@
 //! Hosts the three modules that together implement the MCP server surface:
 //! `tools` (the rmcp adapter endpoints), `mcp` (the `SyncManager` plus
 //! project-path resolver), and `semantic` (the rust-analyzer IDE
-//! wrapper used by analysis tools).
+//! wrapper used by analysis tools), plus `deep_stack`, the thread every one of
+//! them has to borrow before it runs rust-analyzer.
 
 // lancedb 0.29's async stack can push Send inference for the sync-manager
 // background task past the default recursion limit when the runtime owner
@@ -11,6 +12,7 @@
 #![recursion_limit = "512"]
 #![warn(unreachable_pub, dead_code)]
 
+pub(crate) mod deep_stack;
 pub mod tools;
 pub mod mcp;
 pub mod semantic;

--- a/crates/rmc-server/src/mcp/memory.rs
+++ b/crates/rmc-server/src/mcp/memory.rs
@@ -1,0 +1,210 @@
+//! Reading and returning process memory.
+//!
+//! # Why this module exists
+//!
+//! Dropping a loaded rust-analyzer context frees the objects but does not give
+//! the pages back to the kernel. Measured on a live daemon (24-core machine,
+//! one `bur/rust_app` workspace loaded):
+//!
+//! ```text
+//! before                       5291 MB RSS
+//! clear_runtime semantic_only  5291 MB RSS   <- one project dropped, zero bytes returned
+//! clear_runtime all            4922 MB RSS   <- only the search cache gave anything back
+//! ```
+//!
+//! With an *empty* runtime — no projects, no cache entries — the process still
+//! held 4.9 GB: 3.4 GB spread over 323 anonymous regions (glibc's per-thread
+//! arenas, ~64 MB each) plus 1.3 GB in the main heap. rust-analyzer's salsa
+//! database allocates millions of small objects from a rayon pool, which
+//! fragments those arenas; `free()` returns the chunks to the arena and the
+//! arena keeps them.
+//!
+//! So a "clear" that reports success while RSS does not move is telling the
+//! truth about its own bookkeeping and lying about the thing the operator
+//! actually wanted. [`release_free_memory`] is the missing half, and
+//! [`rss_kib`] is what makes the result checkable rather than believed.
+
+/// Resident set size of this process, in KiB.
+///
+/// `None` on platforms without `/proc` — the caller reports "unknown" rather
+/// than inventing a number, because a fabricated zero would read as "we
+/// released everything".
+pub fn rss_kib() -> Option<u64> {
+    #[cfg(target_os = "linux")]
+    {
+        std::fs::read_to_string("/proc/self/status")
+            .ok()
+            .and_then(|status| parse_proc_status_rss_kib(&status))
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        None
+    }
+}
+
+pub(crate) fn parse_proc_status_rss_kib(status: &str) -> Option<u64> {
+    status.lines().find_map(|line| {
+        let value = line.strip_prefix("VmRSS:")?;
+        value.split_whitespace().next()?.parse::<u64>().ok()
+    })
+}
+
+/// mimalloc's own "give it back" entry point.
+///
+/// Declared here rather than imported: `libmimalloc-sys` binds only the
+/// allocation calls (`mi_malloc`, `mi_free`, …) and stops there, while the
+/// symbol itself is part of every mimalloc build. Depending on that crate is
+/// still what puts the library on the link line — the extern block only names a
+/// function it already contains.
+#[cfg(feature = "mimalloc")]
+unsafe extern "C" {
+    fn mi_collect(force: bool);
+}
+
+/// Anchor that keeps `libmimalloc-sys` on the link line.
+///
+/// A bare `extern` block names a symbol without telling the linker where it
+/// lives. `libmimalloc-sys` ships the archive that defines `mi_collect`, but a
+/// dependency nothing references is dropped before linking, and the build then
+/// fails with `undefined symbol: mi_collect` — while the very same code links
+/// fine from the binary crate, which references mimalloc through its
+/// `#[global_allocator]`. Referring to one bound function here is what makes
+/// the archive present in both cases.
+#[cfg(feature = "mimalloc")]
+const _MIMALLOC_LINK_ANCHOR: unsafe extern "C" fn(usize) -> *mut std::ffi::c_void =
+    libmimalloc_sys::mi_malloc;
+
+/// Ask the allocator to return free memory to the kernel.
+///
+/// Returns whether a release was actually attempted: `false` means this build
+/// has no way to do it, which the caller must not present as "nothing needed
+/// releasing".
+///
+/// # Which allocator gets asked
+///
+/// Whichever one is actually linked. With the `mimalloc` feature the global
+/// allocator is mimalloc, and trimming glibc's arenas would be a no-op against
+/// the wrong heap — the exact shape of bug that makes a knob look broken. So
+/// the feature switches the call, not just the allocator.
+///
+/// # What it can and cannot do
+///
+/// `malloc_trim` returns pages that are *entirely* free. A fragmented arena —
+/// one live 64-byte object holding a 64 MB region — stays resident, and no
+/// amount of trimming changes that. Treat a small drop as evidence of
+/// fragmentation, not as a failed call: that is precisely why the caller
+/// measures RSS on both sides instead of assuming.
+pub fn release_free_memory() -> bool {
+    #[cfg(feature = "mimalloc")]
+    {
+        // `true` = force: also return memory from thread-local heaps of threads
+        // that are still alive, which is the whole point here — the rayon pool
+        // that loaded the workspace is still parked, holding its heaps.
+        //
+        // SAFETY: `mi_collect` takes no pointers and is documented as callable
+        // from any thread at any time.
+        unsafe { mi_collect(true) };
+        true
+    }
+    #[cfg(all(not(feature = "mimalloc"), target_os = "linux", target_env = "gnu"))]
+    {
+        // SAFETY: `malloc_trim` takes a pad in bytes and is safe to call at any
+        // time from any thread; it only walks the allocator's own free lists.
+        unsafe { libc::malloc_trim(0) };
+        true
+    }
+    #[cfg(not(any(feature = "mimalloc", all(target_os = "linux", target_env = "gnu"))))]
+    {
+        false
+    }
+}
+
+/// What a release attempt did, in numbers the caller can print.
+///
+/// `before`/`after` are `None` where RSS is unreadable; `released_kib` is then
+/// `None` too rather than `0`, keeping "we could not tell" distinct from "we
+/// freed nothing".
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+pub struct MemoryRelease {
+    pub attempted: bool,
+    pub rss_kib_before: Option<u64>,
+    pub rss_kib_after: Option<u64>,
+    pub released_kib: Option<u64>,
+}
+
+impl MemoryRelease {
+    /// Not attempted, and honest about it.
+    pub fn skipped() -> Self {
+        let rss = rss_kib();
+        Self {
+            attempted: false,
+            rss_kib_before: rss,
+            rss_kib_after: rss,
+            released_kib: None,
+        }
+    }
+}
+
+/// Run `release_free_memory` around an RSS measurement.
+///
+/// Saturating subtraction: RSS can legitimately *rise* across the call when
+/// another thread allocates meanwhile, and a wrapped huge number would be worse
+/// than reporting zero.
+pub fn release_and_measure() -> MemoryRelease {
+    let before = rss_kib();
+    let attempted = release_free_memory();
+    let after = rss_kib();
+    let released = match (before, after) {
+        (Some(before), Some(after)) => Some(before.saturating_sub(after)),
+        _ => None,
+    };
+    MemoryRelease {
+        attempted,
+        rss_kib_before: before,
+        rss_kib_after: after,
+        released_kib: released,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proc_status_parser_reads_rss() {
+        let status = "Name:\ttest\nVmRSS:\t  12345 kB\n";
+
+        assert_eq!(parse_proc_status_rss_kib(status), Some(12345));
+    }
+
+    #[test]
+    fn proc_status_parser_reports_absence_rather_than_zero() {
+        assert_eq!(parse_proc_status_rss_kib("Name:\ttest\n"), None);
+    }
+
+    /// The measurement must survive RSS growing during the call rather than
+    /// wrapping into a nonsense "released 18 exabytes".
+    #[test]
+    fn release_report_never_wraps() {
+        let release = release_and_measure();
+
+        if let Some(released) = release.released_kib {
+            let before = release.rss_kib_before.expect("before present with delta");
+            assert!(
+                released <= before,
+                "released {released} KiB cannot exceed the {before} KiB we started with"
+            );
+        }
+    }
+
+    /// On the platforms we actually ship to, "nothing to release" must not be
+    /// indistinguishable from "this build cannot release".
+    #[cfg(any(feature = "mimalloc", all(target_os = "linux", target_env = "gnu")))]
+    #[test]
+    fn release_is_available_on_supported_builds() {
+        assert!(
+            release_and_measure().attempted,
+            "glibc and mimalloc builds must both have a working release path"
+        );
+    }
+}

--- a/crates/rmc-server/src/mcp/memory.rs
+++ b/crates/rmc-server/src/mcp/memory.rs
@@ -49,6 +49,39 @@ pub(crate) fn parse_proc_status_rss_kib(status: &str) -> Option<u64> {
     })
 }
 
+/// Memory the kernel estimates is available for a new workload, in KiB.
+///
+/// `MemAvailable`, not `MemFree`: page cache and reclaimable slab are free for
+/// the asking, and `MemFree` on a machine that has been up for a day reads as
+/// an emergency when there is none.
+///
+/// This is the one number about the *machine* rather than the process. Without
+/// it a daemon comfortably below its own RSS limit keeps gigabytes of analysis
+/// cached while a `cargo` run next to it goes to swap — the caches belong to
+/// whoever needs the memory more, and a build needs it more than a warm cache.
+///
+/// `None` on platforms without `/proc`, for the same reason as [`rss_kib`]: an
+/// invented number here would read as "plenty of memory".
+pub fn mem_available_kib() -> Option<u64> {
+    #[cfg(target_os = "linux")]
+    {
+        std::fs::read_to_string("/proc/meminfo")
+            .ok()
+            .and_then(|meminfo| parse_proc_meminfo_available_kib(&meminfo))
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        None
+    }
+}
+
+pub(crate) fn parse_proc_meminfo_available_kib(meminfo: &str) -> Option<u64> {
+    meminfo.lines().find_map(|line| {
+        let value = line.strip_prefix("MemAvailable:")?;
+        value.split_whitespace().next()?.parse::<u64>().ok()
+    })
+}
+
 /// mimalloc's own "give it back" entry point.
 ///
 /// Declared here rather than imported: `libmimalloc-sys` binds only the
@@ -180,6 +213,35 @@ mod tests {
     #[test]
     fn proc_status_parser_reports_absence_rather_than_zero() {
         assert_eq!(parse_proc_status_rss_kib("Name:\ttest\n"), None);
+    }
+
+    #[test]
+    fn meminfo_parser_reads_available() {
+        let meminfo = "MemTotal:       64000000 kB\n\
+                       MemFree:         1000000 kB\n\
+                       MemAvailable:   35000000 kB\n";
+
+        assert_eq!(parse_proc_meminfo_available_kib(meminfo), Some(35_000_000));
+    }
+
+    /// `MemFree` must not be mistaken for it: the two differ by the whole page
+    /// cache, and reading the wrong one would starve the daemon on a healthy
+    /// machine.
+    #[test]
+    fn meminfo_parser_does_not_settle_for_memfree() {
+        let meminfo = "MemTotal:       64000000 kB\nMemFree:         1000000 kB\n";
+
+        assert_eq!(parse_proc_meminfo_available_kib(meminfo), None);
+    }
+
+    /// On Linux the reading has to exist, or the floor silently never applies.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn available_memory_is_readable_on_this_platform() {
+        assert!(
+            mem_available_kib().is_some_and(|kib| kib > 0),
+            "MemAvailable must be readable, otherwise the machine-wide floor is dead code"
+        );
     }
 
     /// The measurement must survive RSS growing during the call rather than

--- a/crates/rmc-server/src/mcp/memory.rs
+++ b/crates/rmc-server/src/mcp/memory.rs
@@ -4,7 +4,7 @@
 //!
 //! Dropping a loaded rust-analyzer context frees the objects but does not give
 //! the pages back to the kernel. Measured on a live daemon (24-core machine,
-//! one `bur/rust_app` workspace loaded):
+//! one ~4000-file workspace loaded):
 //!
 //! ```text
 //! before                       5291 MB RSS

--- a/crates/rmc-server/src/mcp/mod.rs
+++ b/crates/rmc-server/src/mcp/mod.rs
@@ -4,6 +4,7 @@
 //! for the rust-code-mcp service.
 
 pub mod defaults;
+pub mod memory;
 pub mod project_paths;
 pub mod runtime;
 pub mod search_cache;
@@ -11,6 +12,7 @@ pub mod sync;
 pub mod workspace_locks;
 
 pub use defaults::*;
+pub use memory::*;
 pub use runtime::*;
 pub use search_cache::*;
 pub use sync::*;

--- a/crates/rmc-server/src/mcp/runtime.rs
+++ b/crates/rmc-server/src/mcp/runtime.rs
@@ -8,6 +8,7 @@ use serde::Serialize;
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
 
+use crate::deep_stack::run_analysis;
 use crate::semantic::{SemanticService, SemanticServiceStatus};
 
 use super::memory::{MemoryRelease, release_and_measure, rss_kib};
@@ -188,6 +189,43 @@ impl RuntimeState {
                 running: self.background_sync_running(),
             },
             process: current_process_status(),
+        }
+    }
+
+    /// Bump the revision of every loaded analysis and sweep the type interner.
+    ///
+    /// The reason this exists at all is in [`SemanticService::collect_garbage`]:
+    /// salsa only evicts LRU-capped memos when the revision bumps, and a project
+    /// nobody edits never bumps on its own. Called on a timer by the daemon's
+    /// watchdog; returns the number of contexts collected, for its log line.
+    ///
+    /// # Two things about *how* it is called
+    ///
+    /// It runs on [`run_analysis`]'s thread, not on a runtime worker: the
+    /// interner sweep recurses over the shape of the analyzed types, and a
+    /// 2 MiB tokio stack is what took the whole server down with an `abort`
+    /// the last time rust-analyzer work was run on one.
+    ///
+    /// It does *not* take the workspace locks that [`Self::clear`] takes. Those
+    /// guard the search index and the sync manager, neither of which this
+    /// touches; taking them on a timer would stall indexing for no reason. The
+    /// lock that matters here is the semantic mutex, which is also what makes
+    /// the collection sound.
+    pub async fn collect_garbage(&self) -> usize {
+        let semantic = Arc::clone(&self.semantic);
+        match run_analysis("collect_garbage", move || {
+            semantic
+                .lock()
+                .expect("semantic service mutex poisoned")
+                .collect_garbage()
+        })
+        .await
+        {
+            Ok(collected) => collected,
+            Err(error) => {
+                tracing::warn!("garbage collection did not run: {}", error.message);
+                0
+            }
         }
     }
 

--- a/crates/rmc-server/src/mcp/runtime.rs
+++ b/crates/rmc-server/src/mcp/runtime.rs
@@ -10,12 +10,15 @@ use tokio::task::JoinHandle;
 
 use crate::semantic::{SemanticService, SemanticServiceStatus};
 
+use super::memory::{MemoryRelease, release_and_measure, rss_kib};
 use super::{
     SearchRuntimeCache, SearchRuntimeCacheStatus, SyncManager, SyncManagerStatus,
     WorkspaceLockRegistry,
 };
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize, Serialize, schemars::JsonSchema)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize, Serialize, schemars::JsonSchema,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum RuntimeClearScope {
     All,
@@ -44,6 +47,14 @@ pub struct RuntimeClearReport {
     pub search_cache_entries_cleared: usize,
     pub semantic_projects_cleared: usize,
     pub sync_directories_untracked: usize,
+    /// What clearing actually did to the process's memory.
+    ///
+    /// Without this the report counted objects it had dropped and said nothing
+    /// about the only quantity the operator came for. A run that clears one
+    /// project and returns zero bytes — the normal case, see
+    /// [`super::memory`] — has to be visible in the answer, not discovered
+    /// later with `ps`.
+    pub memory: MemoryRelease,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -181,10 +192,7 @@ impl RuntimeState {
     }
 
     pub async fn clear(&self, request: RuntimeClearRequest) -> RuntimeClearReport {
-        let workspace = request
-            .workspace
-            .as_deref()
-            .map(normalize_workspace);
+        let workspace = request.workspace.as_deref().map(normalize_workspace);
         if let Some(workspace) = &workspace {
             let _workspace_lock = self.workspace_locks.lock_exclusive(workspace).await;
             self.clear_locked(request.scope, Some(workspace)).await
@@ -205,6 +213,7 @@ impl RuntimeState {
             search_cache_entries_cleared: 0,
             semantic_projects_cleared: 0,
             sync_directories_untracked: 0,
+            memory: MemoryRelease::skipped(),
         };
 
         match (scope, workspace) {
@@ -257,6 +266,12 @@ impl RuntimeState {
                 report.sync_directories_untracked = self.untrack_all().await;
             }
         }
+
+        // After the drops, not before: the allocator can only hand back what the
+        // clear has already released. Called unconditionally, including for the
+        // no-op scopes, so the report always carries a real measurement rather
+        // than sometimes a real one and sometimes a placeholder.
+        report.memory = release_and_measure();
 
         report
     }
@@ -413,28 +428,8 @@ fn normalize_workspace(path: &Path) -> PathBuf {
 fn current_process_status() -> ProcessStatus {
     ProcessStatus {
         pid: std::process::id(),
-        rss_kib: current_rss_kib(),
+        rss_kib: rss_kib(),
     }
-}
-
-fn current_rss_kib() -> Option<u64> {
-    #[cfg(target_os = "linux")]
-    {
-        std::fs::read_to_string("/proc/self/status")
-            .ok()
-            .and_then(|status| parse_proc_status_rss_kib(&status))
-    }
-    #[cfg(not(target_os = "linux"))]
-    {
-        None
-    }
-}
-
-fn parse_proc_status_rss_kib(status: &str) -> Option<u64> {
-    status.lines().find_map(|line| {
-        let value = line.strip_prefix("VmRSS:")?;
-        value.split_whitespace().next()?.parse::<u64>().ok()
-    })
 }
 
 #[cfg(test)]
@@ -493,7 +488,10 @@ mod tests {
         let state = runtime.state();
         let workspace = tempfile::tempdir().expect("create temp workspace");
 
-        let guard = state.workspace_locks().lock_exclusive(workspace.path()).await;
+        let guard = state
+            .workspace_locks()
+            .lock_exclusive(workspace.path())
+            .await;
         let clear_state = state.clone();
         let clear_task = tokio::spawn(async move {
             clear_state
@@ -537,10 +535,30 @@ mod tests {
         assert!(!stopped_status.background_sync.running);
     }
 
-    #[test]
-    fn runtime_proc_status_parser_reads_rss() {
-        let status = "Name:\ttest\nVmRSS:\t  12345 kB\n";
+    /// The defect this closes: `clear` used to report only its own bookkeeping,
+    /// so "one project cleared" and "not one byte returned to the kernel" — the
+    /// normal outcome on glibc — were indistinguishable in the answer.
+    #[tokio::test]
+    async fn runtime_clear_reports_a_real_memory_measurement() {
+        let runtime = ServerRuntime::new(3600);
 
-        assert_eq!(parse_proc_status_rss_kib(status), Some(12345));
+        let report = runtime
+            .state()
+            .clear(RuntimeClearRequest {
+                scope: RuntimeClearScope::SemanticOnly,
+                workspace: None,
+            })
+            .await;
+
+        assert!(
+            report.memory.attempted,
+            "a glibc or mimalloc build must actually attempt the release"
+        );
+        #[cfg(target_os = "linux")]
+        assert!(
+            report.memory.rss_kib_before.is_some_and(|rss| rss > 0),
+            "RSS must be read, not guessed: {:?}",
+            report.memory
+        );
     }
 }

--- a/crates/rmc-server/src/semantic/mod.rs
+++ b/crates/rmc-server/src/semantic/mod.rs
@@ -1087,8 +1087,8 @@ pub fn first() {
     /// # Running it
     ///
     /// ```text
-    /// RMC_RSS_CYCLE_PROJECT=/home/sc/t/bur/rust_app \
-    ///   cargo test -p rmc-server --features migraphx -- --ignored --nocapture rss_across
+    /// RMC_RSS_CYCLE_PROJECT=/absolute/path/to/a/real/workspace \
+    ///   cargo test -p rmc-server -- --ignored --nocapture rss_across
     /// ```
     ///
     /// `RMC_RSS_CYCLE_COUNT` (default 4) and `RMC_RSS_CYCLE_TOLERANCE_MB`

--- a/crates/rmc-server/src/semantic/mod.rs
+++ b/crates/rmc-server/src/semantic/mod.rs
@@ -177,16 +177,22 @@ fn apply_edits(ctx: &mut ProjectContext, paths: &[PathBuf]) -> Result<()> {
 ///
 /// Derived rather than guessed. A freshly started daemon costs ~2.3 GB before
 /// it loads anything (ONNX runtime, embedding model, GPU probe); one
-/// `Fast`-loaded workspace of ~4000 files adds ~3 GB; the memory watchdog's
-/// soft limit is 8192 MB. Two loaded workspaces therefore land right at the
-/// point where the watchdog would start unloading anyway, and a third is memory
-/// that guard has already decided it does not want.
+/// `Fast`-loaded workspace of ~4000 files adds ~3 GB. Three of them come to
+/// ~11.3 GB, which is what the watchdog's soft limit is set to accommodate
+/// (12288 MB); a fourth is memory that guard has already decided against.
+///
+/// It was 2 while the daemon key included the working directory, and 2 was the
+/// right number then: each daemon served one directory, so a second project was
+/// already unusual. One daemon now serves every directory, so the projects a
+/// person moves between during a day all land in the same map — and evicting
+/// one costs the next question in that project a full reload, measured in
+/// minutes on a large workspace.
 ///
 /// What this bounds is a *count*, which is only a proxy for memory — ten tiny
 /// crates cost less than one workspace. The proxy is deliberate: it is the
 /// cheap half of the job, and the watchdog remains the half that measures
 /// actual RSS.
-const DEFAULT_MAX_PROJECTS: usize = 2;
+const DEFAULT_MAX_PROJECTS: usize = 3;
 
 const MAX_PROJECTS_ENV: &str = "RMC_MAX_PROJECTS";
 

--- a/crates/rmc-server/src/semantic/mod.rs
+++ b/crates/rmc-server/src/semantic/mod.rs
@@ -6,20 +6,102 @@ mod rename;
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::time::SystemTime;
 
 use ra_ap_ide::AnalysisHost;
-use ra_ap_vfs::Vfs;
-use anyhow::Result;
+use ra_ap_ide_db::ChangeWithProcMacros;
+use ra_ap_vfs::{FileExcluded, Vfs, VfsPath};
+use anyhow::{Context as _, Result};
+use rmc_indexing::indexing::collect_project_rust_files;
 use serde::Serialize;
 
 pub(crate) use position::Location;
 pub(crate) use rename::RenamePreview;
+
+/// What a `stat` can see about a file — enough to decide whether it is worth
+/// reading, and cheap enough to collect for a whole workspace on every query.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct FileStamp {
+    modified: SystemTime,
+    len: u64,
+}
+
+/// What the working tree did since a project context was built.
+#[derive(Debug)]
+enum Staleness {
+    /// Same files, same stamps: the cached analysis still describes the code.
+    Fresh,
+    /// The same set of files, some of them edited. Their new text can be
+    /// pushed into the existing database.
+    Edited(Vec<PathBuf>),
+    /// Files appeared or disappeared. A new module, a new crate or a deleted
+    /// file changes the module tree and possibly the crate graph, and neither
+    /// can be patched file-by-file — the project has to be loaded again.
+    StructureChanged,
+}
 
 /// Cached project context
 struct ProjectContext {
     host: AnalysisHost,
     vfs: Vfs,
     load_kind: LoadKind,
+    /// The working tree as it was when this context was built or last
+    /// refreshed. Without it the cache has no way to notice that the code
+    /// moved on — see [`SemanticService::refresh_if_stale`].
+    stamps: HashMap<PathBuf, FileStamp>,
+}
+
+fn stamp_of(path: &Path) -> Option<FileStamp> {
+    let meta = std::fs::metadata(path).ok()?;
+    Some(FileStamp {
+        modified: meta.modified().ok()?,
+        len: meta.len(),
+    })
+}
+
+/// Stat every `*.rs` file of the project, using the same walker as the indexer
+/// so both sides mean the same thing by "a project file".
+///
+/// Files that vanish between the walk and the stat are simply absent from the
+/// result, which reads as a deletion — the correct conclusion.
+fn collect_stamps(root: &Path) -> HashMap<PathBuf, FileStamp> {
+    let (files, walk_errors) = collect_project_rust_files(root);
+    if walk_errors > 0 {
+        tracing::warn!(
+            "{} unreadable entries while checking {} for staleness",
+            walk_errors,
+            root.display()
+        );
+    }
+    files
+        .into_iter()
+        .filter_map(|path| stamp_of(&path).map(|stamp| (path, stamp)))
+        .collect()
+}
+
+fn classify_staleness(
+    old: &HashMap<PathBuf, FileStamp>,
+    new: &HashMap<PathBuf, FileStamp>,
+) -> Staleness {
+    if old.len() != new.len() {
+        return Staleness::StructureChanged;
+    }
+
+    let mut edited = Vec::new();
+    for (path, stamp) in new {
+        match old.get(path) {
+            None => return Staleness::StructureChanged,
+            Some(previous) if previous == stamp => {}
+            Some(_) => edited.push(path.clone()),
+        }
+    }
+
+    if edited.is_empty() {
+        Staleness::Fresh
+    } else {
+        edited.sort();
+        Staleness::Edited(edited)
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -47,6 +129,41 @@ pub struct SemanticProjectStatus {
 pub struct SemanticServiceStatus {
     pub project_count: usize,
     pub projects: Vec<SemanticProjectStatus>,
+}
+
+/// Push the current contents of `paths` into an already-loaded analysis.
+///
+/// Fails rather than skips when a file cannot be mapped into the analysis: the
+/// caller turns that into a full reload. Silently leaving one file at its old
+/// revision would reproduce the very defect this module now guards against,
+/// only harder to notice.
+fn apply_edits(ctx: &mut ProjectContext, paths: &[PathBuf]) -> Result<()> {
+    let mut updates = Vec::with_capacity(paths.len());
+
+    // Read everything before mutating anything: a change applied halfway
+    // would leave the database describing a mixture of two revisions.
+    for path in paths {
+        let vfs_path = VfsPath::new_real_path(path.to_string_lossy().into_owned());
+        let (file_id, excluded) = ctx.vfs.file_id(&vfs_path).ok_or_else(|| {
+            anyhow::anyhow!("{} is not part of the loaded analysis", path.display())
+        })?;
+        if excluded == FileExcluded::Yes {
+            anyhow::bail!("{} is excluded from the loaded analysis", path.display());
+        }
+        let text = std::fs::read_to_string(path)
+            .with_context(|| format!("reading {}", path.display()))?;
+        updates.push((vfs_path, file_id, text));
+    }
+
+    let mut change = ChangeWithProcMacros::default();
+    for (vfs_path, file_id, text) in updates {
+        ctx.vfs
+            .set_file_contents(vfs_path, Some(text.clone().into_bytes()));
+        change.change_file(file_id, Some(text));
+    }
+    ctx.host.apply_change(change);
+
+    Ok(())
 }
 
 /// Service for semantic code queries
@@ -120,27 +237,124 @@ impl SemanticService {
         };
 
         if needs_load {
-            tracing::info!(
-                "Loading {:?} IDE for project: {}",
-                requested,
-                canonical.display()
-            );
-            let (host, vfs) = match requested {
-                LoadKind::Fast => loader::load_project(&canonical)?,
-                LoadKind::Full => loader::load_project_full(&canonical)?,
-            };
-            self.projects.insert(
-                canonical,
-                ProjectContext {
-                    host,
-                    vfs,
-                    load_kind: requested,
-                },
-            );
-            tracing::info!("IDE loaded successfully");
+            self.load_kind_into_cache(&canonical, requested)?;
+            return Ok(());
         }
 
+        // Cached — but "cached" said nothing about "current" until this call
+        // existed. See [`Self::refresh_if_stale`].
+        self.refresh_if_stale(&canonical, requested)
+    }
+
+    fn load_kind_into_cache(&mut self, canonical: &Path, requested: LoadKind) -> Result<()> {
+        tracing::info!(
+            "Loading {:?} IDE for project: {}",
+            requested,
+            canonical.display()
+        );
+        // Stamps are taken BEFORE the load, not after: a file edited while
+        // rust-analyzer was reading the workspace must come out stale on the
+        // next query, not silently accepted as already analysed.
+        let stamps = collect_stamps(canonical);
+        let (host, vfs) = match requested {
+            LoadKind::Fast => loader::load_project(canonical)?,
+            LoadKind::Full => loader::load_project_full(canonical)?,
+        };
+        self.projects.insert(
+            canonical.to_path_buf(),
+            ProjectContext {
+                host,
+                vfs,
+                load_kind: requested,
+                stamps,
+            },
+        );
+        tracing::info!("IDE loaded successfully");
         Ok(())
+    }
+
+    /// Bring a cached project up to date with the working tree.
+    ///
+    /// # The defect this closes
+    ///
+    /// A `ProjectContext` is an `AnalysisHost` built from the files as they
+    /// were at load time. Nothing ever invalidated it: the only reload
+    /// condition was upgrading a `Fast` context to `Full`. So every answer
+    /// after the first edit described code that no longer existed —
+    /// `find_references` reporting 2 call sites where the file on disk had 7,
+    /// with no error and no warning anywhere. The only cure was knowing to
+    /// call `clear_runtime scope=semantic_only`, which requires already
+    /// suspecting the answer, which is exactly what a confident wrong answer
+    /// prevents.
+    ///
+    /// # Why two repair paths
+    ///
+    /// Edits to existing files are pushed straight into the salsa database
+    /// (`apply_change`), which invalidates precisely the derived queries that
+    /// depended on those files — milliseconds, and it is what a real IDE does
+    /// on every keystroke. Added or deleted files are not patchable that way:
+    /// they change the module tree, and a new crate changes the crate graph,
+    /// so those force a reload. Reloading costs seconds (`Fast`, `no_deps`) to
+    /// minutes (`Full`), which is why it is reserved for the case that needs
+    /// it rather than used for everything.
+    ///
+    /// # Known limit
+    ///
+    /// Only `*.rs` files are watched. A `Cargo.toml` edited on its own —
+    /// dropping a dependency, renaming a feature — is invisible here. Adding a
+    /// crate is not: its sources are new files, which trips the structural
+    /// path anyway.
+    fn refresh_if_stale(&mut self, canonical: &Path, requested: LoadKind) -> Result<()> {
+        let current = collect_stamps(canonical);
+
+        let staleness = {
+            let ctx = self
+                .projects
+                .get(canonical)
+                .ok_or_else(|| anyhow::anyhow!("Project not loaded"))?;
+            classify_staleness(&ctx.stamps, &current)
+        };
+
+        match staleness {
+            Staleness::Fresh => Ok(()),
+            Staleness::StructureChanged => {
+                tracing::info!(
+                    "Project {} gained or lost files since it was analysed; reloading",
+                    canonical.display()
+                );
+                self.load_kind_into_cache(canonical, requested)
+            }
+            Staleness::Edited(paths) => {
+                let patched = {
+                    let ctx = self
+                        .projects
+                        .get_mut(canonical)
+                        .ok_or_else(|| anyhow::anyhow!("Project not loaded"))?;
+                    apply_edits(ctx, &paths).map(|()| ctx.stamps = current)
+                };
+                match patched {
+                    Ok(()) => {
+                        tracing::info!(
+                            "Refreshed {} edited file(s) in {}",
+                            paths.len(),
+                            canonical.display()
+                        );
+                        Ok(())
+                    }
+                    Err(e) => {
+                        // A file the analysis does not know (excluded from the
+                        // build, unreadable, non-UTF-8) cannot be patched in.
+                        // Falling back to a reload is slow but honest; keeping
+                        // the stale context would be the original defect.
+                        tracing::info!(
+                            "Cannot patch {} incrementally ({e}); reloading",
+                            canonical.display()
+                        );
+                        self.load_kind_into_cache(canonical, requested)
+                    }
+                }
+            }
+        }
     }
 
     /// Search for symbols by name (for find_definition)
@@ -249,6 +463,7 @@ impl SemanticService {
                 host: AnalysisHost::new(None),
                 vfs: Vfs::default(),
                 load_kind: LoadKind::Fast,
+                stamps: HashMap::new(),
             },
         );
     }
@@ -368,10 +583,269 @@ pub fn run(engine: &dyn Engine) {
         assert_eq!(service.clear_all(), 0);
     }
 
+    /// Call sites only. `find_references_by_name` returns the declaration
+    /// alongside them (tagged `"target"` rather than `"reference"`), and
+    /// counting both would make the assertions read one higher than the
+    /// number they are actually about.
+    fn call_sites(locations: &[Location]) -> usize {
+        locations
+            .iter()
+            .filter(|location| location.name == "reference")
+            .count()
+    }
+
+    /// A single-crate workspace with `target()` and one call site.
+    fn one_crate_workspace(root: &Path) -> PathBuf {
+        write_file(
+            &root.join("Cargo.toml"),
+            r#"
+[package]
+name = "staleness_probe"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+path = "src/lib.rs"
+"#,
+        );
+        let lib = root.join("src/lib.rs");
+        write_file(
+            &lib,
+            r#"pub fn target() {}
+
+pub fn first() {
+    target();
+}
+"#,
+        );
+        lib
+    }
+
+    /// The defect: a cached rust-analyzer context was never invalidated, so
+    /// every answer after the first edit described the code as it was at load
+    /// time. Here the second call site is added AFTER the first query, and the
+    /// same service must see it.
+    #[test]
+    fn references_see_an_edit_made_after_the_project_was_cached() {
+        let workspace = tempfile::tempdir().expect("create workspace tempdir");
+        let root = workspace.path();
+        let lib = one_crate_workspace(root);
+
+        let mut service = SemanticService::new();
+        let before = service
+            .find_references_by_name_with_exact(root, "target", true)
+            .expect("first query");
+        assert_eq!(
+            call_sites(&before),
+            1,
+            "positive control: the fixture must start with exactly one call site, got {before:?}"
+        );
+
+        write_file(
+            &lib,
+            r#"pub fn target() {}
+
+pub fn first() {
+    target();
+}
+
+pub fn second() {
+    target();
+}
+"#,
+        );
+
+        let after = service
+            .find_references_by_name_with_exact(root, "target", true)
+            .expect("query after edit");
+        assert_eq!(
+            call_sites(&after),
+            2,
+            "the edit must be visible without clearing the cache, got {after:?}"
+        );
+    }
+
+    /// A new file changes the module tree, which cannot be patched into the
+    /// database file-by-file — the refresh has to notice and reload.
+    #[test]
+    fn references_see_a_call_site_added_in_a_new_file() {
+        let workspace = tempfile::tempdir().expect("create workspace tempdir");
+        let root = workspace.path();
+        let lib = one_crate_workspace(root);
+
+        let mut service = SemanticService::new();
+        let before = service
+            .find_references_by_name_with_exact(root, "target", true)
+            .expect("first query");
+        assert_eq!(call_sites(&before), 1, "positive control: {before:?}");
+
+        write_file(
+            &root.join("src/extra.rs"),
+            r#"pub fn third() {
+    crate::target();
+}
+"#,
+        );
+        write_file(
+            &lib,
+            r#"pub mod extra;
+
+pub fn target() {}
+
+pub fn first() {
+    target();
+}
+"#,
+        );
+
+        let after = service
+            .find_references_by_name_with_exact(root, "target", true)
+            .expect("query after new file");
+        assert_eq!(
+            call_sites(&after),
+            2,
+            "a call site in a file added after load must be visible, got {after:?}"
+        );
+    }
+
+    /// Untouched code must not pay for the check: same stamps, no reload, and
+    /// crucially the same answer.
+    #[test]
+    fn an_untouched_project_is_not_reloaded() {
+        let workspace = tempfile::tempdir().expect("create workspace tempdir");
+        let root = workspace.path();
+        one_crate_workspace(root);
+
+        let mut service = SemanticService::new();
+        service
+            .find_references_by_name_with_exact(root, "target", true)
+            .expect("first query");
+
+        let canonical = root.canonicalize().expect("canonicalize");
+        let stamps_before = service.projects[&canonical].stamps.clone();
+
+        service
+            .find_references_by_name_with_exact(root, "target", true)
+            .expect("second query");
+
+        assert!(
+            matches!(
+                classify_staleness(&stamps_before, &service.projects[&canonical].stamps),
+                Staleness::Fresh
+            ),
+            "an untouched tree must classify as fresh"
+        );
+    }
+
     fn write_file(path: &Path, contents: &str) {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent).expect("create parent dir");
         }
         fs::write(path, contents.trim_start()).expect("write fixture file");
+    }
+
+    /// Does rust-analyzer *leak*, or does the allocator merely keep what it
+    /// freed? Both look identical from outside — RSS goes up and stays up — and
+    /// they need opposite fixes, so this measures rather than assumes.
+    ///
+    /// # How it tells them apart
+    ///
+    /// Each cycle loads the workspace, drops the context, and asks the
+    /// allocator to hand memory back. The number that matters is RSS *after*
+    /// that release, cycle over cycle:
+    ///
+    /// - flat across cycles → nothing leaks; the resident memory is
+    ///   fragmentation the allocator is sitting on, and the cure is the
+    ///   allocator (the `mimalloc` feature), not rust-analyzer;
+    /// - rising by roughly the same amount every cycle → a genuine leak, and
+    ///   the per-cycle step is its size. rust-analyzer interns symbols in
+    ///   process-global tables that are never freed, so a small constant step
+    ///   is expected; a step near the cost of a whole load is not.
+    ///
+    /// The first cycle is excluded from the verdict: it pays one-time costs
+    /// (proc-macro server, lazily built tables) that never recur.
+    ///
+    /// # Running it
+    ///
+    /// ```text
+    /// RMC_RSS_CYCLE_PROJECT=/home/sc/t/bur/rust_app \
+    ///   cargo test -p rmc-server --features migraphx -- --ignored --nocapture rss_across
+    /// ```
+    ///
+    /// `RMC_RSS_CYCLE_COUNT` (default 4) and `RMC_RSS_CYCLE_TOLERANCE_MB`
+    /// (default 512) tune length and verdict.
+    #[test]
+    #[ignore = "needs a real workspace in RMC_RSS_CYCLE_PROJECT and minutes to run"]
+    fn rss_across_load_clear_cycles_separates_a_leak_from_fragmentation() {
+        let Ok(project) = std::env::var("RMC_RSS_CYCLE_PROJECT") else {
+            panic!(
+                "set RMC_RSS_CYCLE_PROJECT to a cargo workspace root; without one this test \
+                 would measure nothing and pass, which is worse than not running"
+            );
+        };
+        let project = PathBuf::from(project);
+        let cycles = env_usize("RMC_RSS_CYCLE_COUNT", 4);
+        let tolerance_mb = env_usize("RMC_RSS_CYCLE_TOLERANCE_MB", 512) as u64;
+        assert!(cycles >= 2, "a verdict needs at least two cycles");
+
+        let mut after_release = Vec::with_capacity(cycles);
+        for cycle in 0..cycles {
+            let mut service = SemanticService::new();
+            // A real query, not a bare load: this is what fills the salsa
+            // database in production, and an empty database would understate
+            // both fragmentation and any leak.
+            let found = service
+                .symbol_search(&project, "main", 16)
+                .expect("symbol search on the probe workspace");
+            let loaded = crate::mcp::memory::rss_kib().expect("RSS readable on linux");
+
+            service.clear_all();
+            drop(service);
+            let release = crate::mcp::memory::release_and_measure();
+            let settled = release.rss_kib_after.expect("RSS readable on linux");
+            after_release.push(settled);
+
+            println!(
+                "cycle {cycle}: {} symbol(s), loaded {} MB, after clear+release {} MB (released {:?} KiB)",
+                found.len(),
+                loaded / 1024,
+                settled / 1024,
+                release.released_kib,
+            );
+        }
+
+        // Compare the second cycle with the last: the first is warm-up.
+        let baseline = after_release[1];
+        let final_rss = *after_release.last().expect("cycles >= 2");
+        let growth_kib = final_rss.saturating_sub(baseline);
+        let per_cycle_kib = growth_kib / (cycles as u64 - 1).max(1);
+
+        println!(
+            "verdict: grew {} MB over {} cycles after warm-up ({} MB per cycle); tolerance {} MB",
+            growth_kib / 1024,
+            cycles - 1,
+            per_cycle_kib / 1024,
+            tolerance_mb,
+        );
+
+        assert!(
+            growth_kib / 1024 <= tolerance_mb,
+            "RSS after clear+release grew {} MB across {} cycles ({} MB per cycle) — that is a \
+             leak, not fragmentation, since every cycle drops its context and trims. Baseline \
+             {} MB, final {} MB, all cycles: {:?} MB",
+            growth_kib / 1024,
+            cycles - 1,
+            per_cycle_kib / 1024,
+            baseline / 1024,
+            final_rss / 1024,
+            after_release.iter().map(|kib| kib / 1024).collect::<Vec<_>>(),
+        );
+    }
+
+    fn env_usize(name: &str, default: usize) -> usize {
+        std::env::var(name)
+            .ok()
+            .and_then(|value| value.trim().parse::<usize>().ok())
+            .unwrap_or(default)
     }
 }

--- a/crates/rmc-server/src/semantic/mod.rs
+++ b/crates/rmc-server/src/semantic/mod.rs
@@ -49,6 +49,13 @@ struct ProjectContext {
     /// refreshed. Without it the cache has no way to notice that the code
     /// moved on — see [`SemanticService::refresh_if_stale`].
     stamps: HashMap<PathBuf, FileStamp>,
+    /// Value of [`SemanticService::clock`] when this context was last asked a
+    /// question. Orders eviction — see [`SemanticService::evict_to_capacity`].
+    ///
+    /// A counter rather than a `SystemTime`: eviction needs the *order* of
+    /// uses, and a wall clock can step backwards (NTP, suspend) and reorder
+    /// them.
+    last_used: u64,
 }
 
 fn stamp_of(path: &Path) -> Option<FileStamp> {
@@ -166,15 +173,60 @@ fn apply_edits(ctx: &mut ProjectContext, paths: &[PathBuf]) -> Result<()> {
     Ok(())
 }
 
+/// How many project contexts may stay loaded at once. `0` means unlimited.
+///
+/// Derived rather than guessed. A freshly started daemon costs ~2.3 GB before
+/// it loads anything (ONNX runtime, embedding model, GPU probe); one
+/// `Fast`-loaded workspace of ~4000 files adds ~3 GB; the memory watchdog's
+/// soft limit is 8192 MB. Two loaded workspaces therefore land right at the
+/// point where the watchdog would start unloading anyway, and a third is memory
+/// that guard has already decided it does not want.
+///
+/// What this bounds is a *count*, which is only a proxy for memory — ten tiny
+/// crates cost less than one workspace. The proxy is deliberate: it is the
+/// cheap half of the job, and the watchdog remains the half that measures
+/// actual RSS.
+const DEFAULT_MAX_PROJECTS: usize = 2;
+
+const MAX_PROJECTS_ENV: &str = "RMC_MAX_PROJECTS";
+
+fn max_projects_from_env() -> usize {
+    std::env::var(MAX_PROJECTS_ENV)
+        .ok()
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .unwrap_or(DEFAULT_MAX_PROJECTS)
+}
+
 /// Service for semantic code queries
 pub(crate) struct SemanticService {
     projects: HashMap<PathBuf, ProjectContext>,
+    /// Upper bound on `projects`; `0` disables eviction entirely.
+    ///
+    /// # The defect this closes
+    ///
+    /// Before it, the map had no TTL, no LRU and no ceiling: every directory a
+    /// session ever asked about kept its rust-analyzer context until the
+    /// process died. A daemon outlives its clients by design, so nothing
+    /// bounded that — measured 2026-08-27, one daemon sat on 14.6 GB, most of
+    /// it contexts for directories nobody had touched in hours.
+    max_projects: usize,
+    /// Monotonic tick, handed out by [`Self::touch`]. Only its order matters.
+    clock: u64,
 }
 
 impl SemanticService {
     pub(crate) fn new() -> Self {
+        Self::with_max_projects(max_projects_from_env())
+    }
+
+    /// The cap as an argument rather than as an environment variable, so a test
+    /// can state the capacity it is judging instead of arranging the process
+    /// environment around it.
+    pub(crate) fn with_max_projects(max_projects: usize) -> Self {
         Self {
             projects: HashMap::new(),
+            max_projects,
+            clock: 0,
         }
     }
 
@@ -218,6 +270,96 @@ impl SemanticService {
         }
     }
 
+    /// Give every loaded analysis a revision bump and sweep the type interner.
+    ///
+    /// # Why a daemon has to do this by hand
+    ///
+    /// salsa evicts an LRU-capped query's memos in exactly one place:
+    /// `for_each_evicted`, reached from `reset_for_new_revision`. That is to
+    /// say, **capacities only mean something at the moment the revision bumps**,
+    /// and a revision bumps when a file changes. An IDE gets those for free on
+    /// every keystroke; a project sitting in this daemon that nobody has edited
+    /// for hours never bumps at all, so its capacity — whatever it is set to —
+    /// evicts nothing, ever. Those are precisely the cold contexts that made a
+    /// daemon 14.6 GB. This call is where the bump comes from instead.
+    ///
+    /// `AnalysisHost::trigger_garbage_collection` is a synthetic write plus a
+    /// mark-and-sweep over the interned type storage, and rust-analyzer's own
+    /// main loop calls it the same way when its worker pools go quiet.
+    ///
+    /// # Why calling it with several hosts loaded is sound
+    ///
+    /// The sweep is process-global — the type interner is shared by every
+    /// `AnalysisHost` here — but its roots are refcounts (`Arc::strong_count(item) > 1`
+    /// marks alive), so a type another host holds is a root and survives. What
+    /// the `unsafe` really demands is that no query be *in flight*, holding a
+    /// type it has not recorded anywhere yet. Every path into this service goes
+    /// through one `Mutex<SemanticService>`, and this method needs `&mut self`,
+    /// so holding that lock means no analysis is running in any project.
+    ///
+    /// # Cost
+    ///
+    /// The sweep runs once per host, so N loaded projects pay N sweeps; the
+    /// caller keeps this off the hot path (see the watchdog's interval) rather
+    /// than the method trying to be clever about it. The bump itself is paid
+    /// later, by the next query re-validating its memos.
+    ///
+    /// Returns the number of contexts collected, for the log line.
+    pub(crate) fn collect_garbage(&mut self) -> usize {
+        for (path, ctx) in self.projects.iter_mut() {
+            tracing::debug!("collecting garbage in {}", path.display());
+            ctx.host.trigger_garbage_collection();
+        }
+        self.projects.len()
+    }
+
+    /// Mark `canonical` as the most recently used context.
+    fn touch(&mut self, canonical: &Path) {
+        self.clock += 1;
+        let clock = self.clock;
+        if let Some(ctx) = self.projects.get_mut(canonical) {
+            ctx.last_used = clock;
+        }
+    }
+
+    /// Drop the least recently used contexts until [`Self::max_projects`] holds.
+    ///
+    /// `keep` is never evicted whatever its age: it is the project the caller is
+    /// about to answer a question about, and evicting it would mean reloading it
+    /// on the very next line. With a cap of 1 that is the whole rule — the
+    /// working project stays, everything else goes.
+    ///
+    /// Returns how many contexts were dropped.
+    fn evict_to_capacity(&mut self, keep: &Path) -> usize {
+        if self.max_projects == 0 {
+            return 0;
+        }
+
+        let mut evicted = 0;
+        while self.projects.len() > self.max_projects {
+            let victim = self
+                .projects
+                .iter()
+                .filter(|(path, _)| path.as_path() != keep)
+                .min_by_key(|(_, ctx)| ctx.last_used)
+                .map(|(path, _)| path.clone());
+
+            // Only `keep` is left: the cap is smaller than one project, and one
+            // is the least we can hold and still answer.
+            let Some(victim) = victim else { break };
+
+            tracing::info!(
+                "unloading {} to stay within {}={} loaded project(s)",
+                victim.display(),
+                MAX_PROJECTS_ENV,
+                self.max_projects
+            );
+            self.projects.remove(&victim);
+            evicted += 1;
+        }
+        evicted
+    }
+
     /// Get or load project (lazy loading)
     fn get_or_load(&mut self, project_path: &Path) -> Result<()> {
         self.get_or_load_kind(project_path, LoadKind::Fast)
@@ -236,14 +378,20 @@ impl SemanticService {
             None => true,
         };
 
-        if needs_load {
-            self.load_kind_into_cache(&canonical, requested)?;
-            return Ok(());
-        }
+        let outcome = if needs_load {
+            self.load_kind_into_cache(&canonical, requested)
+        } else {
+            // Cached — but "cached" said nothing about "current" until this call
+            // existed. See [`Self::refresh_if_stale`].
+            self.refresh_if_stale(&canonical, requested)
+        };
+        outcome?;
 
-        // Cached — but "cached" said nothing about "current" until this call
-        // existed. See [`Self::refresh_if_stale`].
-        self.refresh_if_stale(&canonical, requested)
+        // Both branches, and only after they succeeded: a load that failed left
+        // no context to order, and a query that never happened is not a use.
+        self.touch(&canonical);
+        self.evict_to_capacity(&canonical);
+        Ok(())
     }
 
     fn load_kind_into_cache(&mut self, canonical: &Path, requested: LoadKind) -> Result<()> {
@@ -260,6 +408,7 @@ impl SemanticService {
             LoadKind::Fast => loader::load_project(canonical)?,
             LoadKind::Full => loader::load_project_full(canonical)?,
         };
+        self.clock += 1;
         self.projects.insert(
             canonical.to_path_buf(),
             ProjectContext {
@@ -267,6 +416,7 @@ impl SemanticService {
                 vfs,
                 load_kind: requested,
                 stamps,
+                last_used: self.clock,
             },
         );
         tracing::info!("IDE loaded successfully");
@@ -457,6 +607,7 @@ impl SemanticService {
     pub(crate) fn insert_test_project_fast(&mut self, project_path: PathBuf) {
         let canonical =
             std::fs::canonicalize(&project_path).unwrap_or(project_path);
+        self.clock += 1;
         self.projects.insert(
             canonical,
             ProjectContext {
@@ -464,6 +615,7 @@ impl SemanticService {
                 vfs: Vfs::default(),
                 load_kind: LoadKind::Fast,
                 stamps: HashMap::new(),
+                last_used: self.clock,
             },
         );
     }
@@ -742,6 +894,167 @@ pub fn first() {
             fs::create_dir_all(parent).expect("create parent dir");
         }
         fs::write(path, contents.trim_start()).expect("write fixture file");
+    }
+
+    /// Which projects the service is currently holding, canonicalized, so an
+    /// assertion can name them instead of counting them.
+    fn loaded(service: &SemanticService) -> Vec<PathBuf> {
+        let mut paths: Vec<_> = service.projects.keys().cloned().collect();
+        paths.sort();
+        paths
+    }
+
+    /// The cap has to evict by *use*, not by arrival. A queue that dropped the
+    /// oldest arrival would throw away the project the session actually works
+    /// in, which is the one it will ask about next.
+    #[test]
+    fn a_third_project_evicts_the_least_recently_used_not_the_oldest() {
+        let (first, second, third) = (
+            tempfile::tempdir().expect("tempdir a"),
+            tempfile::tempdir().expect("tempdir b"),
+            tempfile::tempdir().expect("tempdir c"),
+        );
+        for dir in [&first, &second, &third] {
+            one_crate_workspace(dir.path());
+        }
+
+        let mut service = SemanticService::with_max_projects(2);
+        for dir in [&first, &second] {
+            service
+                .symbol_search(dir.path(), "target", 8)
+                .expect("load project");
+        }
+
+        // The point of the test: `first` arrived first but is used last, so it
+        // is `second` that must go when `third` needs the room.
+        service
+            .symbol_search(first.path(), "target", 8)
+            .expect("re-query the first project");
+        service
+            .symbol_search(third.path(), "target", 8)
+            .expect("load the third project");
+
+        let mut expected = vec![
+            first.path().canonicalize().expect("canonicalize first"),
+            third.path().canonicalize().expect("canonicalize third"),
+        ];
+        expected.sort();
+        assert_eq!(
+            loaded(&service),
+            expected,
+            "the cap must keep the two most recently used projects"
+        );
+    }
+
+    /// A cap of one is the interesting edge: every load evicts everything else,
+    /// and the one thing that must survive is the project being asked about.
+    #[test]
+    fn the_project_being_used_is_never_the_victim() {
+        let (first, second) = (
+            tempfile::tempdir().expect("tempdir a"),
+            tempfile::tempdir().expect("tempdir b"),
+        );
+        for dir in [&first, &second] {
+            one_crate_workspace(dir.path());
+        }
+
+        let mut service = SemanticService::with_max_projects(1);
+        service
+            .symbol_search(first.path(), "target", 8)
+            .expect("load the first project");
+        let found = service
+            .symbol_search(second.path(), "target", 8)
+            .expect("load the second project");
+
+        assert!(
+            !found.is_empty(),
+            "positive control: the surviving project must still answer, got {found:?}"
+        );
+        assert_eq!(
+            loaded(&service),
+            vec![second.path().canonicalize().expect("canonicalize second")],
+            "the project just queried is the one that stays"
+        );
+    }
+
+    /// `0` means unlimited, the same as it does for the daemon's other knobs.
+    #[test]
+    fn a_cap_of_zero_evicts_nothing() {
+        let dirs: Vec<_> = (0..3)
+            .map(|_| tempfile::tempdir().expect("tempdir"))
+            .collect();
+
+        let mut service = SemanticService::with_max_projects(0);
+        for dir in &dirs {
+            service.insert_test_project_fast(dir.path().to_path_buf());
+        }
+        let kept = service.projects.keys().next().cloned().expect("a project");
+        assert_eq!(service.evict_to_capacity(&kept), 0);
+        assert_eq!(
+            service.project_count(),
+            3,
+            "an unlimited cap holds everything"
+        );
+    }
+
+    /// Two things at once, because the collection can fail in two directions.
+    ///
+    /// *That it happened*: the whole point is the revision bump — without one,
+    /// salsa never reaches `for_each_evicted` and an LRU capacity evicts
+    /// nothing. A collection that returned a count without bumping would look
+    /// exactly like a working one from the outside, so the revision is read
+    /// directly.
+    ///
+    /// *That it was safe*: the sweep is `unsafe` and process-global. Had it
+    /// freed something still in use, the symptom would be a wrong answer or a
+    /// crash on the next query — hence the same question on both sides of it.
+    #[test]
+    fn a_collection_bumps_the_revision_and_keeps_the_answers() {
+        use ra_ap_ide_db::base_db::SourceDatabase;
+
+        let workspace = tempfile::tempdir().expect("create workspace tempdir");
+        let root = workspace.path();
+        one_crate_workspace(root);
+
+        let mut service = SemanticService::new();
+        let before = service
+            .find_references_by_name_with_exact(root, "target", true)
+            .expect("query before collection");
+        assert_eq!(
+            call_sites(&before),
+            1,
+            "positive control: the fixture must start with one call site, got {before:?}"
+        );
+
+        let canonical = root.canonicalize().expect("canonicalize");
+        let revision_before = service.projects[&canonical]
+            .host
+            .raw_database()
+            .nonce_and_revision();
+
+        assert_eq!(
+            service.collect_garbage(),
+            1,
+            "the collection must visit the loaded project"
+        );
+
+        let revision_after = service.projects[&canonical]
+            .host
+            .raw_database()
+            .nonce_and_revision();
+        assert_ne!(
+            revision_before, revision_after,
+            "without a revision bump the LRU capacities never evict anything"
+        );
+
+        let after = service
+            .find_references_by_name_with_exact(root, "target", true)
+            .expect("query after collection");
+        assert_eq!(
+            call_sites(&after),
+            call_sites(&before),
+            "collecting garbage must not change what the analysis knows, got {after:?}"
+        );
     }
 
     /// Does rust-analyzer *leak*, or does the allocator merely keep what it

--- a/crates/rmc-server/src/tools/endpoints/analysis.rs
+++ b/crates/rmc-server/src/tools/endpoints/analysis.rs
@@ -92,8 +92,13 @@ use tracing;
 use rmc_engine::parser::RustParser;
 
 use crate::semantic::SemanticService;
+use crate::tools::paths::require_absolute;
 
 fn validate_cargo_project_directory(project_path: &Path) -> Result<(), McpError> {
+    // Absolute first: the daemon does not share a cwd with the caller, so a
+    // relative directory would resolve — and then quietly answer — elsewhere.
+    require_absolute("directory", project_path)?;
+
     if !project_path.exists() {
         return Err(McpError::invalid_params(
             format!("directory does not exist: {}", project_path.display()),
@@ -656,5 +661,33 @@ edition = "2021"
 
     fn test_semantic() -> Arc<Mutex<SemanticService>> {
         Arc::new(Mutex::new(SemanticService::new()))
+    }
+
+    /// `find_definition`, `find_references`, `rename_symbol`, `get_dependencies`,
+    /// `get_call_graph` and `analyze_complexity` all reach the filesystem through
+    /// this one validator, so the gate lives here rather than six times over.
+    ///
+    /// Mutation that must fail it: drop the `require_absolute` call — a relative
+    /// directory then passes whenever the daemon's own tree happens to contain a
+    /// `Cargo.toml`, and the tool answers about that project instead.
+    #[test]
+    fn a_relative_project_directory_is_refused() {
+        let err = validate_cargo_project_directory(Path::new("crates/rmc-server"))
+            .expect_err("a relative directory must be refused");
+
+        assert!(
+            err.message.contains("must be an absolute path"),
+            "got: {}",
+            err.message
+        );
+    }
+
+    /// Positive control: a real absolute project still validates, so the test
+    /// above is about relativeness and not about rejecting everything.
+    #[test]
+    fn an_absolute_project_directory_still_validates() {
+        let project = valid_temp_project();
+
+        validate_cargo_project_directory(project.path()).expect("an absolute project is fine");
     }
 }

--- a/crates/rmc-server/src/tools/endpoints/cache.rs
+++ b/crates/rmc-server/src/tools/endpoints/cache.rs
@@ -79,15 +79,18 @@ struct TargetDirectory {
     hashes: Vec<String>,
 }
 
-fn target_directory(directory: &str) -> TargetDirectory {
-    let raw = PathBuf::from(directory);
-    let canonical = std::fs::canonicalize(&raw).unwrap_or_else(|_| raw.clone());
-    let canonical_hash = dir_hash(&canonical);
-    let raw_hash = dir_hash(&raw);
-    let mut hashes = vec![canonical_hash];
-    if raw_hash != hashes[0] {
-        hashes.push(raw_hash);
-    }
+/// Resolve the directory whose caches are to be cleared.
+///
+/// Only the canonical path contributes a hash. The raw path used to contribute
+/// a second one, which was a footgun once paths stopped being relative to the
+/// caller's own tree: `clear_cache(".")` would hash the literal `"."` and wipe
+/// whatever the daemon's own directory hashed to. Relative paths are refused
+/// before reaching here, and `dir_hash` canonicalizes, so the raw hash can only
+/// ever have been the wrong answer.
+fn target_directory(directory: &Path) -> TargetDirectory {
+    let raw = directory.to_path_buf();
+    let canonical = std::fs::canonicalize(&raw).unwrap_or(raw);
+    let hashes = vec![dir_hash(&canonical)];
 
     TargetDirectory { canonical, hashes }
 }
@@ -113,7 +116,8 @@ pub(crate) async fn clear_cache(
 
     if let Some(ref directory) = params.directory {
         // Clear cache for specific project
-        let target = target_directory(directory);
+        let directory = crate::tools::paths::require_absolute("directory", directory)?;
+        let target = target_directory(&directory);
         let _workspace_lock = workspace_locks.lock_exclusive(&target.canonical).await;
         if !dry_run {
             if let Some(sync_manager) = sync_manager {

--- a/crates/rmc-server/src/tools/endpoints/health.rs
+++ b/crates/rmc-server/src/tools/endpoints/health.rs
@@ -67,9 +67,16 @@ pub(crate) async fn health_check(
     // profile (automatic CPU default when unset); further down we still read the
     // on-disk `metadata.json` so the report reflects the real cached
     // identity.
-    let root = directory.as_deref().unwrap_or(".");
-    let backend =
-        resolve_embedding_backend_for_mcp(embedding_profile.as_deref(), std::path::Path::new(root))?;
+    // A system-wide check (no `directory`) deliberately looks at no project's
+    // `embedding_profiles.toml`: the filesystem root has none, so the probe
+    // falls back to the built-in default. It used to pass `"."`, which after
+    // the daemon stopped sharing a cwd with its clients would have meant
+    // "whatever directory the daemon happens to sit in".
+    let root = match directory.as_deref() {
+        Some(dir) => crate::tools::paths::require_absolute("directory", dir)?,
+        None => std::path::PathBuf::from("/"),
+    };
+    let backend = resolve_embedding_backend_for_mcp(embedding_profile.as_deref(), &root)?;
     let embedder_identity = backend.identity();
 
     // Determine paths using the same shared helper as index_tool.

--- a/crates/rmc-server/src/tools/endpoints/index.rs
+++ b/crates/rmc-server/src/tools/endpoints/index.rs
@@ -11,7 +11,6 @@ use crate::mcp::defaults::{automatic_embedding_backend, is_background_embedding_
 use crate::mcp::project_paths::{ProjectPaths, resolve_embedding_backend_for_mcp};
 use rmc_engine::vector_store::VectorStoreError;
 use rmcp::{ErrorData as McpError, model::CallToolResult, model::Content, schemars};
-use std::path::PathBuf;
 use tracing;
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
@@ -178,7 +177,7 @@ pub async fn index_codebase(
     workspace_locks: &crate::mcp::WorkspaceLockRegistry,
     search_cache: Option<&crate::mcp::SearchRuntimeCache>,
 ) -> Result<CallToolResult, McpError> {
-    let dir = PathBuf::from(&params.directory);
+    let dir = crate::tools::paths::require_absolute("directory", &params.directory)?;
     let force = params.force_reindex.unwrap_or(false);
 
     // Validate directory

--- a/crates/rmc-server/src/tools/endpoints/index.rs
+++ b/crates/rmc-server/src/tools/endpoints/index.rs
@@ -3,13 +3,11 @@
 //! Provides the `index_codebase` tool which allows manual triggering of
 //! incremental indexing with optional force reindex.
 
-use rmc_engine::embeddings::{EmbeddingBackend, Qwen3Variant};
-use rmc_indexing::indexing::{
-    index_project_incrementally, IncrementalIndexRequest, IndexStats,
-};
 use crate::mcp::defaults::{automatic_embedding_backend, is_background_embedding_backend};
 use crate::mcp::project_paths::{ProjectPaths, resolve_embedding_backend_for_mcp};
+use rmc_engine::embeddings::{EmbeddingBackend, Qwen3Variant};
 use rmc_engine::vector_store::VectorStoreError;
+use rmc_indexing::indexing::{IncrementalIndexRequest, IndexStats, index_project_incrementally};
 use rmcp::{ErrorData as McpError, model::CallToolResult, model::Content, schemars};
 use tracing;
 
@@ -77,13 +75,24 @@ fn format_index_codebase_result(
             Profile: {}\n\
             Embedder: {}\n\
             Skipped files: {}\n\
+            Retryable failures: {}\n\
             Time: {:?}",
-            directory, profile_name, embedder_identity, stats.skipped_files, elapsed
+            directory,
+            profile_name,
+            embedder_identity,
+            stats.skipped_files,
+            stats.failed_files,
+            elapsed
         );
     }
 
     if stats.indexed_files == 0 {
-        let heading = if stats.skipped_files == 0 {
+        let heading = if stats.failed_files > 0 {
+            format!(
+                "⚠ Indexing incomplete for '{}' — failed files will be retried",
+                directory
+            )
+        } else if stats.skipped_files == 0 {
             format!("✓ Index already up to date for '{}'", directory)
         } else {
             format!("✓ No files needed indexing updates in '{}'", directory)
@@ -97,6 +106,7 @@ fn format_index_codebase_result(
             - Total chunks: {}\n\
             - Unchanged files: {}\n\
             - Skipped or removed files: {}\n\
+            - Retryable failures: {}\n\
             - Time: {:?}\n\n\
             Profile: {}\n\
             Embedder: {}\n\
@@ -107,6 +117,7 @@ fn format_index_codebase_result(
             stats.total_chunks,
             stats.unchanged_files,
             stats.skipped_files,
+            stats.failed_files,
             elapsed,
             profile_name,
             embedder_identity,
@@ -115,20 +126,30 @@ fn format_index_codebase_result(
         );
     }
 
+    let heading = if stats.failed_files == 0 {
+        format!("✓ Successfully indexed '{}'", directory)
+    } else {
+        format!(
+            "⚠ Partially indexed '{}' — failed files will be retried",
+            directory
+        )
+    };
+
     format!(
-        "✓ Successfully indexed '{}'\n\n\
+        "{}\n\n\
         Indexing stats:\n\
         - Total Rust files: {}\n\
         - Indexed files: {} {}\n\
         - Total chunks: {}\n\
         - Unchanged files: {}\n\
         - Skipped or removed files: {}\n\
+        - Retryable failures: {}\n\
         - Time: {:?}\n\n\
         Profile: {}\n\
         Embedder: {}\n\
         Background sync: {}\n\
         Collection: {}",
-        directory,
+        heading,
         stats.total_files,
         stats.indexed_files,
         if force {
@@ -139,6 +160,7 @@ fn format_index_codebase_result(
         stats.total_chunks,
         stats.unchanged_files,
         stats.skipped_files,
+        stats.failed_files,
         elapsed,
         profile_name,
         embedder_identity,
@@ -190,7 +212,10 @@ pub async fn index_codebase(
 
     if !dir.is_dir() {
         return Err(McpError::invalid_params(
-            format!("The specified path '{}' is not a directory", params.directory),
+            format!(
+                "The specified path '{}' is not a directory",
+                params.directory
+            ),
             None,
         ));
     }
@@ -260,7 +285,10 @@ pub async fn index_codebase(
         backend.profile.name(),
         &embedder_identity,
         &paths.collection_name,
-        match (sync_manager.is_some(), is_background_embedding_backend(&backend)) {
+        match (
+            sync_manager.is_some(),
+            is_background_embedding_backend(&backend),
+        ) {
             (false, _) => "disabled",
             (true, true) => "enabled (5-minute interval; CPU/remote profiles only)",
             (true, false) => "enabled, but this local CUDA profile is not synced in background",
@@ -375,6 +403,7 @@ mod tests {
             unchanged_files: 28,
             skipped_files: 0,
             total_chunks: 120,
+            ..Default::default()
         };
 
         let text = format_index_codebase_result(
@@ -402,6 +431,7 @@ mod tests {
             unchanged_files: 0,
             skipped_files: 28,
             total_chunks: 0,
+            ..Default::default()
         };
 
         let text = format_index_codebase_result(
@@ -429,6 +459,7 @@ mod tests {
             unchanged_files: 0,
             skipped_files: 0,
             total_chunks: 0,
+            ..Default::default()
         };
 
         let text = format_index_codebase_result(
@@ -443,6 +474,32 @@ mod tests {
         );
 
         assert!(text.contains("No Rust files suitable"));
+    }
+
+    #[test]
+    fn format_result_does_not_call_a_retryable_partial_run_success() {
+        let stats = IndexStats {
+            total_files: 4,
+            indexed_files: 2,
+            failed_files: 2,
+            ..Default::default()
+        };
+
+        let text = format_index_codebase_result(
+            &stats,
+            "/workspace",
+            "local-gpu-small",
+            "test-embedder:v1",
+            "test_collection",
+            "enabled",
+            false,
+            std::time::Duration::from_millis(33),
+        );
+
+        assert!(text.contains("Partially indexed"));
+        assert!(text.contains("failed files will be retried"));
+        assert!(text.contains("- Retryable failures: 2"));
+        assert!(!text.contains("Successfully indexed"));
     }
 
     #[test]
@@ -502,8 +559,7 @@ mod tests {
 
     #[test]
     fn resolve_backend_explicit_model_keeps_default_limits() {
-        let backend =
-            resolve_backend(None, Some("qwen3-0.6b"), std::path::Path::new(".")).unwrap();
+        let backend = resolve_backend(None, Some("qwen3-0.6b"), std::path::Path::new(".")).unwrap();
         let default = EmbeddingBackend::default();
 
         assert_eq!(backend.qwen3_variant(), Some(Qwen3Variant::Embedding0_6B));

--- a/crates/rmc-server/src/tools/endpoints/query.rs
+++ b/crates/rmc-server/src/tools/endpoints/query.rs
@@ -22,7 +22,8 @@ use rmc_engine::vector_store::VectorStore;
 
 /// Read and return the content of a specified file
 pub(crate) async fn read_file_content(file_path: &str) -> Result<CallToolResult, McpError> {
-    let file_path_obj = Path::new(file_path);
+    let file_path_obj = crate::tools::paths::require_absolute("file_path", file_path)?;
+    let file_path_obj = file_path_obj.as_path();
 
     if !file_path_obj.exists() {
         return Err(McpError::invalid_params(
@@ -384,7 +385,8 @@ pub(crate) async fn search(
     workspace_locks: &crate::mcp::WorkspaceLockRegistry,
     search_cache: Option<&SearchRuntimeCache>,
 ) -> Result<CallToolResult, McpError> {
-    let dir_path = Path::new(directory);
+    let dir_path = crate::tools::paths::require_absolute("directory", directory)?;
+    let dir_path = dir_path.as_path();
     if !dir_path.is_dir() {
         return Err(McpError::invalid_params(
             format!("The specified path '{}' is not a directory", directory),
@@ -471,7 +473,8 @@ pub(crate) async fn get_similar_code(
     workspace_locks: &crate::mcp::WorkspaceLockRegistry,
     search_cache: Option<&SearchRuntimeCache>,
 ) -> Result<CallToolResult, McpError> {
-    let dir_path = Path::new(directory);
+    let dir_path = crate::tools::paths::require_absolute("directory", directory)?;
+    let dir_path = dir_path.as_path();
     if !dir_path.is_dir() {
         return Err(McpError::invalid_params(
             format!("The specified path '{}' is not a directory", directory),

--- a/crates/rmc-server/src/tools/graph/audits.rs
+++ b/crates/rmc-server/src/tools/graph/audits.rs
@@ -4,19 +4,20 @@
 //! endpoint follows the shape documented in `graph_tools.rs`: parse MCP
 //! parameters, call graph-owned audit entry points, paginate, serialize.
 //!
-//! Graph audit facade calls are synchronous, so endpoint handlers wrap them in
-//! `spawn_blocking` before rendering MCP responses.
+//! Graph audit facade calls are synchronous and recursive over the analyzed
+//! source, so endpoint handlers hand them to `deep_stack::run_analysis` before
+//! rendering MCP responses.
 
 use std::path::PathBuf;
 
+use crate::tools::graph::deep_stack::run_analysis;
+use crate::tools::graph::response::*;
 use rmc_graph::graph::{
     ChannelCapacityAuditOptions, ChannelCapacityFinding, FnBodyAuditFinding, FnBodyAuditOptions,
     GraphAuditError, MutStaticAuditFinding, RecursionCheckOptions, RecursionCycle,
-    UnsafeAuditFinding,
-    run_channel_capacity_audit, run_fn_body_audit, run_mut_static_audit, run_recursion_check,
-    run_unsafe_audit,
+    UnsafeAuditFinding, run_channel_capacity_audit, run_fn_body_audit, run_mut_static_audit,
+    run_recursion_check, run_unsafe_audit,
 };
-use crate::tools::graph::response::*;
 
 use rmcp::{ErrorData as McpError, model::CallToolResult};
 
@@ -35,9 +36,8 @@ pub(crate) async fn unsafe_audit(
     params: crate::tools::params::UnsafeAuditParams,
 ) -> Result<CallToolResult, McpError> {
     let directory = PathBuf::from(&params.directory);
-    let findings = tokio::task::spawn_blocking(move || run_unsafe_audit(&directory))
-        .await
-        .map_err(|e| McpError::internal_error(format!("spawn_blocking join error: {e}"), None))?
+    let findings = run_analysis("unsafe_audit", move || run_unsafe_audit(&directory))
+        .await?
         .map_err(graph_audit_error("unsafe_audit"))?;
 
     #[derive(serde::Serialize)]
@@ -62,9 +62,8 @@ pub(crate) async fn mut_static_audit(
     params: crate::tools::params::MutStaticAuditParams,
 ) -> Result<CallToolResult, McpError> {
     let directory = PathBuf::from(&params.directory);
-    let findings = tokio::task::spawn_blocking(move || run_mut_static_audit(&directory))
-        .await
-        .map_err(|e| McpError::internal_error(format!("spawn_blocking join error: {e}"), None))?
+    let findings = run_analysis("mut_static_audit", move || run_mut_static_audit(&directory))
+        .await?
         .map_err(graph_audit_error("mut_static_audit"))?;
 
     #[derive(serde::Serialize)]
@@ -97,7 +96,7 @@ pub(crate) async fn recursion_check(
     let directory = PathBuf::from(&params.directory);
     let crate_name = params.crate_name.clone();
     let max_cycle_length = params.max_cycle_length;
-    let output = tokio::task::spawn_blocking(move || {
+    let output = run_analysis("recursion_check", move || {
         run_recursion_check(
             &directory,
             RecursionCheckOptions {
@@ -106,8 +105,7 @@ pub(crate) async fn recursion_check(
             },
         )
     })
-    .await
-    .map_err(|e| McpError::internal_error(format!("spawn_blocking join error: {e}"), None))?
+    .await?
     .map_err(graph_audit_error("recursion_check"))?;
 
     #[derive(serde::Serialize)]
@@ -147,7 +145,7 @@ pub(crate) async fn channel_capacity_audit(
     let crate_name = params.crate_name.clone();
     let skip_test_fns = params.skip_test_fns.unwrap_or(true);
 
-    let findings = tokio::task::spawn_blocking(move || {
+    let findings = run_analysis("channel_capacity_audit", move || {
         run_channel_capacity_audit(
             &directory,
             ChannelCapacityAuditOptions {
@@ -156,9 +154,8 @@ pub(crate) async fn channel_capacity_audit(
             },
         )
     })
-        .await
-        .map_err(|e| McpError::internal_error(format!("spawn_blocking join error: {e}"), None))?
-        .map_err(graph_audit_error("channel_capacity_audit"))?;
+    .await?
+    .map_err(graph_audit_error("channel_capacity_audit"))?;
 
     #[derive(serde::Serialize)]
     struct ScopeSummary {
@@ -197,7 +194,7 @@ pub(crate) async fn fn_body_audit(
     let patterns = params.patterns.clone();
     let skip_test_fns = params.skip_test_fns.unwrap_or(true);
 
-    let output = tokio::task::spawn_blocking(move || {
+    let output = run_analysis("fn_body_audit", move || {
         run_fn_body_audit(
             &directory,
             FnBodyAuditOptions {
@@ -207,9 +204,8 @@ pub(crate) async fn fn_body_audit(
             },
         )
     })
-        .await
-        .map_err(|e| McpError::internal_error(format!("spawn_blocking join error: {e}"), None))?
-        .map_err(graph_audit_error("fn_body_audit"))?;
+    .await?
+    .map_err(graph_audit_error("fn_body_audit"))?;
 
     #[derive(serde::Serialize)]
     struct ScopeSummary {

--- a/crates/rmc-server/src/tools/graph/audits.rs
+++ b/crates/rmc-server/src/tools/graph/audits.rs
@@ -10,7 +10,7 @@
 
 use std::path::PathBuf;
 
-use crate::tools::graph::deep_stack::run_analysis;
+use crate::deep_stack::run_analysis;
 use crate::tools::graph::response::*;
 use rmc_graph::graph::{
     ChannelCapacityAuditOptions, ChannelCapacityFinding, FnBodyAuditFinding, FnBodyAuditOptions,

--- a/crates/rmc-server/src/tools/graph/codemap.rs
+++ b/crates/rmc-server/src/tools/graph/codemap.rs
@@ -83,9 +83,8 @@ pub(crate) async fn handle_build_codemap(
     let max_incoming_per_node = max_incoming_per_node.unwrap_or(8);
     let include_snippets = include_snippets.unwrap_or(false);
 
-    let _workspace_lock = workspace_locks
-        .lock_shared(std::path::Path::new(directory))
-        .await;
+    let directory_path = crate::tools::paths::require_absolute("directory", directory)?;
+    let _workspace_lock = workspace_locks.lock_shared(&directory_path).await;
 
     let opts = CodemapOptions {
         max_nodes,

--- a/crates/rmc-server/src/tools/graph/core.rs
+++ b/crates/rmc-server/src/tools/graph/core.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 
 use serde::Serialize;
 
-use crate::tools::graph::deep_stack::run_analysis;
+use crate::deep_stack::run_analysis;
 use crate::tools::graph::response::*;
 use crate::tools::params::{
     BuildHypergraphParams, CallGraphParams, CallersInCrateParams, CallsFromParams,

--- a/crates/rmc-server/src/tools/graph/core.rs
+++ b/crates/rmc-server/src/tools/graph/core.rs
@@ -10,17 +10,18 @@ use std::path::PathBuf;
 
 use serde::Serialize;
 
-use rmc_graph::graph::{
-    BuildOptions, CallGraphNode, EnrichedBinding, EnrichedCallSite, EnrichedUsage, ModuleDependency,
-    ModuleDependencySymbol, ModuleTreeNode, NodeKind, RecursiveCallersCount, UsageSummaryRow,
-    WorkspaceStats, build_and_persist,
-};
+use crate::tools::graph::deep_stack::run_analysis;
 use crate::tools::graph::response::*;
 use crate::tools::params::{
     BuildHypergraphParams, CallGraphParams, CallersInCrateParams, CallsFromParams,
     GraphDeclaredReexportsParams, GraphExportsParams, GraphImportsParams, GraphReexportsParams,
     ModuleDependenciesParams, ModuleTreeParams, RecursiveCallersCountParams, WhoCallsParams,
     WhoImportsParams, WhoUsesParams, WhoUsesSummaryParams, WorkspaceStatsParams,
+};
+use rmc_graph::graph::{
+    BuildOptions, CallGraphNode, EnrichedBinding, EnrichedCallSite, EnrichedUsage,
+    ModuleDependency, ModuleDependencySymbol, ModuleTreeNode, NodeKind, RecursiveCallersCount,
+    UsageSummaryRow, WorkspaceStats, build_and_persist,
 };
 
 use rmcp::{ErrorData as McpError, model::CallToolResult};
@@ -40,11 +41,11 @@ pub(crate) async fn build_hypergraph(
         ..Default::default()
     };
     // build_and_persist runs `loader::load` + the full extract pass + LMDB
-    // writes synchronously (4-18s wall-clock). Hand off to a blocking thread
-    // so the tokio runtime worker stays free to handle other tool calls.
-    let result = tokio::task::spawn_blocking(move || build_and_persist(&dir, opts))
-        .await
-        .map_err(|e| McpError::internal_error(format!("spawn_blocking join error: {e}"), None))?
+    // writes synchronously (4-18s wall-clock). Hand off to a dedicated thread
+    // so the tokio runtime worker stays free to handle other tool calls — and
+    // so the recursive extract pass gets a stack it fits in (see `deep_stack`).
+    let result = run_analysis("build_hypergraph", move || build_and_persist(&dir, opts))
+        .await?
         .map_err(|e| McpError::internal_error(format!("build_hypergraph failed: {e:#}"), None))?;
 
     json_result(&BuildHypergraphResponse {
@@ -146,7 +147,9 @@ pub(crate) async fn get_exports(params: GraphExportsParams) -> Result<CallToolRe
     })
 }
 
-pub(crate) async fn get_reexports(params: GraphReexportsParams) -> Result<CallToolResult, McpError> {
+pub(crate) async fn get_reexports(
+    params: GraphReexportsParams,
+) -> Result<CallToolResult, McpError> {
     let snap = open_workspace_snapshot(&params.directory)?;
     let module_id = resolve_required_node(&snap, &params.module, NodeKind::Module)?;
     let consumer_id = resolve_required_node(&snap, &params.consumer, NodeKind::Module)?;
@@ -404,7 +407,9 @@ pub(crate) async fn module_tree(params: ModuleTreeParams) -> Result<CallToolResu
     json_result(&ModuleTreeResponse { tree })
 }
 
-pub(crate) async fn workspace_stats(params: WorkspaceStatsParams) -> Result<CallToolResult, McpError> {
+pub(crate) async fn workspace_stats(
+    params: WorkspaceStatsParams,
+) -> Result<CallToolResult, McpError> {
     let snap = open_workspace_snapshot(&params.directory)?;
     let stats: WorkspaceStats = snap
         .workspace_stats()
@@ -412,10 +417,7 @@ pub(crate) async fn workspace_stats(params: WorkspaceStatsParams) -> Result<Call
     json_result(&stats)
 }
 
-pub(crate) fn call_site_views(
-    sites: Vec<EnrichedCallSite>,
-    summary: bool,
-) -> Vec<CallSiteView> {
+pub(crate) fn call_site_views(sites: Vec<EnrichedCallSite>, summary: bool) -> Vec<CallSiteView> {
     sites
         .into_iter()
         .map(|site| CallSiteView {
@@ -429,17 +431,18 @@ pub(crate) fn call_site_views(
         .collect()
 }
 
-fn module_dependency_view(
-    dependency: ModuleDependency,
-    summary: bool,
-) -> ModuleDependencyView {
+fn module_dependency_view(dependency: ModuleDependency, summary: bool) -> ModuleDependencyView {
     ModuleDependencyView {
         target_module: dependency.target_module,
         target_kind: dependency.target_kind,
         target_crate: dependency.target_crate,
         import_count: dependency.import_count,
         usage_count: dependency.usage_count,
-        symbols: if summary { None } else { Some(dependency.symbols) },
+        symbols: if summary {
+            None
+        } else {
+            Some(dependency.symbols)
+        },
     }
 }
 

--- a/crates/rmc-server/src/tools/graph/deep_stack.rs
+++ b/crates/rmc-server/src/tools/graph/deep_stack.rs
@@ -1,0 +1,110 @@
+//! Running rust-analyzer work on a stack deep enough for it.
+//!
+//! Every graph tool here loads a workspace through rust-analyzer and then walks
+//! HIR/AST trees recursively. That recursion is bounded by the *shape of the
+//! analyzed source*, not by anything we control, and it does not fit in the
+//! 2 MiB stack a tokio blocking-pool thread gets by default: building the
+//! hypergraph for this very workspace aborted the process with
+//!
+//! ```text
+//! thread 'tokio-rt-worker' has overflowed its stack
+//! fatal runtime error: stack overflow, aborting
+//! ```
+//!
+//! A stack overflow is an `abort`, not a `panic` — it takes the whole MCP
+//! server down rather than failing one tool call, so this is not something a
+//! caller can guard against. The work therefore carries its own stack instead
+//! of depending on whoever spawned it.
+
+use rmcp::ErrorData as McpError;
+
+/// Stack for the analysis thread.
+///
+/// Measured, not guessed: the default 2 MiB aborts on this workspace, 32 MiB
+/// completes it. 64 MiB doubles the headroom that measurement gives us, and
+/// costs only address space — thread stacks are mapped lazily, so the pages a
+/// shallower walk never touches are never backed by memory.
+const ANALYSIS_STACK_BYTES: usize = 64 * 1024 * 1024;
+
+/// Run blocking rust-analyzer work on a dedicated thread with a deep stack, and
+/// await its result.
+///
+/// Replaces `tokio::task::spawn_blocking` for this kind of work. The blocking
+/// pool is otherwise the right tool — the point of the swap is solely the stack
+/// size, which the pool does not let us set per task.
+pub(crate) async fn run_analysis<T, F>(what: &'static str, work: F) -> Result<T, McpError>
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
+{
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    std::thread::Builder::new()
+        .name("rmc-analysis".to_string())
+        .stack_size(ANALYSIS_STACK_BYTES)
+        .spawn(move || {
+            // A send error means the caller went away; nothing to report to.
+            let _ = tx.send(work());
+        })
+        .map_err(|error| {
+            McpError::internal_error(
+                format!("{what}: failed to spawn analysis thread: {error}"),
+                None,
+            )
+        })?;
+
+    // The sender is dropped without sending only if the thread panicked, which
+    // is the same failure `spawn_blocking` reported as a join error.
+    rx.await
+        .map_err(|_| McpError::internal_error(format!("{what}: analysis thread panicked"), None))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn a_result_travels_back_from_the_analysis_thread() {
+        let value = run_analysis("test", || 6 * 7)
+            .await
+            .expect("analysis result");
+        assert_eq!(value, 42);
+    }
+
+    #[tokio::test]
+    async fn recursion_that_overflows_a_default_thread_completes_here() {
+        // Positive control for the stack size itself rather than for the
+        // plumbing: this frame chain needs far more than the 2 MiB a tokio
+        // blocking thread would hand us, so the test fails by aborting if
+        // `stack_size` ever stops being applied.
+        fn burn(depth: usize, sink: &mut u64) -> u64 {
+            // A big live frame, kept from being optimized away by feeding it
+            // into the running sum.
+            let block = [0xABu8; 8192];
+            *sink = sink.wrapping_add(block[depth % block.len()] as u64);
+            if depth == 0 {
+                *sink
+            } else {
+                burn(depth - 1, sink)
+            }
+        }
+
+        let mut sink = 0;
+        // ~1000 frames × 8 KiB ≈ 8 MiB of live frames.
+        let total = run_analysis("test", move || burn(1000, &mut sink))
+            .await
+            .expect("deep recursion completes");
+        assert!(total > 0, "the recursion must actually have run");
+    }
+
+    #[tokio::test]
+    async fn a_panicking_analysis_is_reported_rather_than_hanging() {
+        let outcome: Result<(), McpError> =
+            run_analysis("test", || panic!("boom in analysis")).await;
+        let error = outcome.expect_err("a panic must surface as an error");
+        assert!(
+            error.message.contains("panicked"),
+            "unexpected error message: {}",
+            error.message
+        );
+    }
+}

--- a/crates/rmc-server/src/tools/graph/mod.rs
+++ b/crates/rmc-server/src/tools/graph/mod.rs
@@ -11,6 +11,7 @@ pub(super) mod audits;
 pub(super) mod codemap;
 pub(super) mod core;
 pub(super) mod crates;
+pub(super) mod deep_stack;
 pub(super) mod response;
 pub(super) mod skeleton;
 pub(super) mod similarity;

--- a/crates/rmc-server/src/tools/graph/mod.rs
+++ b/crates/rmc-server/src/tools/graph/mod.rs
@@ -11,7 +11,6 @@ pub(super) mod audits;
 pub(super) mod codemap;
 pub(super) mod core;
 pub(super) mod crates;
-pub(super) mod deep_stack;
 pub(super) mod response;
 pub(super) mod skeleton;
 pub(super) mod similarity;

--- a/crates/rmc-server/src/tools/graph/response.rs
+++ b/crates/rmc-server/src/tools/graph/response.rs
@@ -8,7 +8,6 @@
 
 use std::collections::HashMap;
 use std::path::Path;
-use std::path::PathBuf;
 
 use rmcp::{
     ErrorData as McpError,
@@ -20,6 +19,7 @@ use rmc_graph::graph::{
     ItemKind, Node, NodeId, NodeKind, OpenedSnapshot, OverlapScope, open_current_for_workspace,
 };
 use crate::tools::params::ListPaginationParams;
+use crate::tools::paths::require_absolute;
 
 pub(crate) const DEFAULT_LIST_LIMIT: usize = 50;
 
@@ -77,7 +77,7 @@ pub(crate) fn clear_locations_for_summary<T>(
 }
 
 pub(crate) fn open_workspace_snapshot(directory: &str) -> Result<OpenedSnapshot, McpError> {
-    let dir = PathBuf::from(directory);
+    let dir = require_absolute("directory", directory)?;
     let canonical = dir.canonicalize().map_err(|e| {
         McpError::invalid_params(format!("failed to canonicalize {directory}: {e}"), None)
     })?;
@@ -261,4 +261,51 @@ pub(crate) fn resolve_chunk_to_item(
         }
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The gate has to be *in* this function, not merely available: about sixty
+    /// graph and audit tools reach the filesystem through here, and this is the
+    /// one place that decides for all of them.
+    ///
+    /// Mutation that must fail it: drop the `require_absolute` call in
+    /// `open_workspace_snapshot` — the refusal then comes from `canonicalize`
+    /// instead, and says "failed to canonicalize .", which reads as a missing
+    /// directory rather than as a request the daemon cannot answer.
+    /// `OpenedSnapshot` has no `Debug`, so the error is taken by hand rather
+    /// than with `expect_err`.
+    fn refusal_of(directory: &str) -> McpError {
+        match open_workspace_snapshot(directory) {
+            Ok(_) => panic!("{directory} was opened, but it must not be"),
+            Err(err) => err,
+        }
+    }
+
+    #[test]
+    fn a_relative_directory_is_refused_before_anything_touches_the_disk() {
+        let err = refusal_of(".");
+
+        assert!(
+            err.message.contains("must be an absolute path"),
+            "the refusal must name the real problem, got: {}",
+            err.message
+        );
+    }
+
+    /// Positive control: an absolute path gets past the gate and fails, if it
+    /// fails, for its own reasons. Without this the test above would also pass
+    /// if the gate refused everything.
+    #[test]
+    fn an_absolute_directory_gets_past_the_gate() {
+        let err = refusal_of("/nonexistent-workspace-for-tests");
+
+        assert!(
+            !err.message.contains("must be an absolute path"),
+            "an absolute path must not be refused by the gate, got: {}",
+            err.message
+        );
+    }
 }

--- a/crates/rmc-server/src/tools/graph/similarity.rs
+++ b/crates/rmc-server/src/tools/graph/similarity.rs
@@ -33,9 +33,11 @@ pub(crate) async fn similar_to_item(
     workspace_locks: &crate::mcp::WorkspaceLockRegistry,
     search_cache: Option<&crate::mcp::SearchRuntimeCache>,
 ) -> Result<CallToolResult, McpError> {
-    let _workspace_lock = workspace_locks
-        .lock_shared(Path::new(&params.directory))
-        .await;
+    // The gate comes before the lock: locking by a relative path would key the
+    // registry on a string that means different directories to different
+    // callers.
+    let directory = crate::tools::paths::require_absolute("directory", &params.directory)?;
+    let _workspace_lock = workspace_locks.lock_shared(&directory).await;
 
     // 1. Resolve seed Item from the hypergraph snapshot.
     let snap = open_workspace_snapshot(&params.directory)?;

--- a/crates/rmc-server/src/tools/graph/skeleton.rs
+++ b/crates/rmc-server/src/tools/graph/skeleton.rs
@@ -4,7 +4,7 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     ffi::OsStr,
     fs, io,
-    path::{Component, Path, PathBuf},
+    path::{Component, Path},
 };
 
 use serde::Serialize;
@@ -21,7 +21,7 @@ pub(crate) async fn crate_skeleton(
 ) -> Result<CallToolResult, McpError> {
     validate_include(params.include.as_deref())?;
 
-    let canonical = PathBuf::from(&params.directory)
+    let canonical = crate::tools::paths::require_absolute("directory", &params.directory)?
         .canonicalize()
         .map_err(|e| {
             McpError::invalid_params(

--- a/crates/rmc-server/src/tools/graph/skeleton.rs
+++ b/crates/rmc-server/src/tools/graph/skeleton.rs
@@ -9,7 +9,7 @@ use std::{
 
 use serde::Serialize;
 
-use crate::tools::graph::deep_stack::run_analysis;
+use crate::deep_stack::run_analysis;
 use crate::tools::graph::response::*;
 use crate::tools::params::CrateSkeletonParams;
 use rmc_graph::graph::{SkeletonFile, SkeletonOptions, render_crate_skeletons};

--- a/crates/rmc-server/src/tools/graph/skeleton.rs
+++ b/crates/rmc-server/src/tools/graph/skeleton.rs
@@ -9,11 +9,10 @@ use std::{
 
 use serde::Serialize;
 
-use rmc_graph::graph::{
-    SkeletonFile, SkeletonOptions, render_crate_skeletons,
-};
+use crate::tools::graph::deep_stack::run_analysis;
 use crate::tools::graph::response::*;
 use crate::tools::params::CrateSkeletonParams;
+use rmc_graph::graph::{SkeletonFile, SkeletonOptions, render_crate_skeletons};
 
 use rmcp::{ErrorData as McpError, model::CallToolResult};
 
@@ -39,14 +38,11 @@ pub(crate) async fn crate_skeleton(
     let page_req = list_page(&params.pagination);
     let opts = graph_options(&params);
 
-    let response = tokio::task::spawn_blocking(move || {
+    let response = run_analysis("crate_skeleton", move || {
         let snap = open_workspace_snapshot(&directory)?;
         if clean && skeleton_dir.exists() {
             fs::remove_dir_all(&skeleton_dir).map_err(|e| {
-                McpError::internal_error(
-                    format!("remove {}: {e}", skeleton_dir.display()),
-                    None,
-                )
+                McpError::internal_error(format!("remove {}: {e}", skeleton_dir.display()), None)
             })?;
         }
         let output = render_crate_skeletons(&snap, &opts)
@@ -67,8 +63,7 @@ pub(crate) async fn crate_skeleton(
                 items: file.items,
             });
         }
-        let aggregate_summaries =
-            write_aggregate_files(&skeleton_dir, &snapshot_id, aggregates)?;
+        let aggregate_summaries = write_aggregate_files(&skeleton_dir, &snapshot_id, aggregates)?;
         let total_aggregate_files = aggregate_summaries.len();
         let total_aggregate_bytes = aggregate_summaries
             .iter()
@@ -113,8 +108,7 @@ pub(crate) async fn crate_skeleton(
                 .collect(),
         })
     })
-    .await
-    .map_err(|e| McpError::internal_error(format!("spawn_blocking join error: {e}"), None))??;
+    .await??;
 
     json_result(&response)
 }
@@ -170,16 +164,11 @@ fn graph_options(params: &CrateSkeletonParams) -> SkeletonOptions {
     let defaults = SkeletonOptions::default();
     SkeletonOptions {
         crates: params.crates.clone(),
-        include: params
-            .include
-            .clone()
-            .unwrap_or(defaults.include),
+        include: params.include.clone().unwrap_or(defaults.include),
         include_docs: params.include_docs.unwrap_or(defaults.include_docs),
         include_attrs: params.include_attrs.unwrap_or(defaults.include_attrs),
         include_impls: params.include_impls.unwrap_or(defaults.include_impls),
-        skip_test_items: params
-            .skip_test_items
-            .unwrap_or(defaults.skip_test_items),
+        skip_test_items: params.skip_test_items.unwrap_or(defaults.skip_test_items),
         exclude_vendor: params.exclude_vendor.unwrap_or(defaults.exclude_vendor),
     }
 }
@@ -205,7 +194,8 @@ fn validate_include(include: Option<&[String]>) -> Result<(), McpError> {
 }
 
 fn ensure_exact_skeleton_child(root: &Path, skeleton_dir: &Path) -> Result<(), McpError> {
-    if skeleton_dir.parent() != Some(root) || skeleton_dir.file_name() != Some(OsStr::new(".skeleton"))
+    if skeleton_dir.parent() != Some(root)
+        || skeleton_dir.file_name() != Some(OsStr::new(".skeleton"))
     {
         return Err(McpError::invalid_params(
             format!(
@@ -222,7 +212,10 @@ fn safe_relative_source_path(source_path: &str) -> Result<&Path, McpError> {
     let path = Path::new(source_path);
     if path.is_absolute()
         || path.components().any(|component| {
-            matches!(component, Component::ParentDir | Component::RootDir | Component::Prefix(_))
+            matches!(
+                component,
+                Component::ParentDir | Component::RootDir | Component::Prefix(_)
+            )
         })
     {
         return Err(McpError::internal_error(
@@ -238,14 +231,15 @@ fn push_aggregate_file(
     file: &SkeletonFile,
 ) -> Result<(), McpError> {
     let file_name = aggregate_file_name(&file.crate_name, &file.source_path)?;
-    let entry = aggregates
-        .entry(file_name.clone())
-        .or_insert_with(|| CrateSkeletonAggregateBuilder {
-            file_name,
-            crate_names: BTreeSet::new(),
-            source_files: Vec::new(),
-            items: 0,
-        });
+    let entry =
+        aggregates
+            .entry(file_name.clone())
+            .or_insert_with(|| CrateSkeletonAggregateBuilder {
+                file_name,
+                crate_names: BTreeSet::new(),
+                source_files: Vec::new(),
+                items: 0,
+            });
     entry.crate_names.insert(file.crate_name.clone());
     entry.items += file.items;
     entry.source_files.push(CrateSkeletonAggregateSource {
@@ -314,10 +308,7 @@ fn write_aggregate_files(
     Ok(summaries)
 }
 
-fn render_aggregate_file(
-    snapshot_id: &str,
-    aggregate: &CrateSkeletonAggregateBuilder,
-) -> String {
+fn render_aggregate_file(snapshot_id: &str, aggregate: &CrateSkeletonAggregateBuilder) -> String {
     let mut content = String::new();
     content.push_str("// @generated by rust-code-mcp crate_skeleton\n");
     content.push_str(&format!("// snapshot: {snapshot_id}\n"));
@@ -364,20 +355,14 @@ fn write_skeleton_file(
     create_skeleton_parent_dirs(skeleton_dir, parent)?;
     ensure_output_file_is_not_symlink(&output_path)?;
     fs::write(&output_path, content).map_err(|e| {
-        McpError::internal_error(
-            format!("write {}: {e}", output_path.display()),
-            None,
-        )
+        McpError::internal_error(format!("write {}: {e}", output_path.display()), None)
     })
 }
 
 fn create_skeleton_parent_dirs(skeleton_dir: &Path, parent: &Path) -> Result<(), McpError> {
     ensure_existing_skeleton_ancestors_not_symlinks(skeleton_dir, parent)?;
     fs::create_dir_all(parent).map_err(|e| {
-        McpError::internal_error(
-            format!("create directory {}: {e}", parent.display()),
-            None,
-        )
+        McpError::internal_error(format!("create directory {}: {e}", parent.display()), None)
     })?;
     ensure_existing_skeleton_ancestors_not_symlinks(skeleton_dir, parent)
 }
@@ -422,24 +407,20 @@ fn ensure_existing_skeleton_ancestors_not_symlinks(
 
 fn inspect_existing_skeleton_ancestor(path: &Path) -> Result<(), McpError> {
     match fs::symlink_metadata(path) {
-        Ok(metadata) if metadata.file_type().is_symlink() => {
-            Err(McpError::internal_error(
-                format!(
-                    "refusing to write through symlinked skeleton path: {}",
-                    path.display()
-                ),
-                None,
-            ))
-        }
-        Ok(metadata) if !metadata.file_type().is_dir() => {
-            Err(McpError::internal_error(
-                format!(
-                    "refusing to write through non-directory skeleton path: {}",
-                    path.display()
-                ),
-                None,
-            ))
-        }
+        Ok(metadata) if metadata.file_type().is_symlink() => Err(McpError::internal_error(
+            format!(
+                "refusing to write through symlinked skeleton path: {}",
+                path.display()
+            ),
+            None,
+        )),
+        Ok(metadata) if !metadata.file_type().is_dir() => Err(McpError::internal_error(
+            format!(
+                "refusing to write through non-directory skeleton path: {}",
+                path.display()
+            ),
+            None,
+        )),
         Ok(_) => Ok(()),
         Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
         Err(err) => Err(McpError::internal_error(
@@ -451,15 +432,13 @@ fn inspect_existing_skeleton_ancestor(path: &Path) -> Result<(), McpError> {
 
 fn ensure_output_file_is_not_symlink(output_path: &Path) -> Result<(), McpError> {
     match fs::symlink_metadata(output_path) {
-        Ok(metadata) if metadata.file_type().is_symlink() => {
-            Err(McpError::internal_error(
-                format!(
-                    "refusing to overwrite symlinked skeleton file: {}",
-                    output_path.display()
-                ),
-                None,
-            ))
-        }
+        Ok(metadata) if metadata.file_type().is_symlink() => Err(McpError::internal_error(
+            format!(
+                "refusing to overwrite symlinked skeleton file: {}",
+                output_path.display()
+            ),
+            None,
+        )),
         Ok(_) => Ok(()),
         Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
         Err(err) => Err(McpError::internal_error(
@@ -488,8 +467,7 @@ mod tests {
             "rmc-config.rs"
         );
         assert_eq!(
-            aggregate_file_name("rmc_config", "src/config.rs")
-                .expect("aggregate file name"),
+            aggregate_file_name("rmc_config", "src/config.rs").expect("aggregate file name"),
             "rmc_config.rs"
         );
     }
@@ -510,9 +488,8 @@ mod tests {
         let mut aggregates = BTreeMap::new();
         push_aggregate_file(&mut aggregates, &file).expect("push aggregate file");
 
-        let summaries =
-            write_aggregate_files(&skeleton_dir, "snapshot-id", aggregates)
-                .expect("write aggregate files");
+        let summaries = write_aggregate_files(&skeleton_dir, "snapshot-id", aggregates)
+            .expect("write aggregate files");
 
         assert_eq!(summaries.len(), 1);
         assert_eq!(summaries[0].skeleton_path, ".skeleton/rmc-server.rs");

--- a/crates/rmc-server/src/tools/graph/tests.rs
+++ b/crates/rmc-server/src/tools/graph/tests.rs
@@ -203,10 +203,19 @@ async fn mcp_round_trip_against_self() {
     assert!(body.contains("\"node_count\""), "build response: {body}");
     assert!(body.contains("\"binding_count\""));
 
+    // The assertion below is about `load` being IN the graph, so the call has
+    // to see every binding. `imports_of` returns them in node-id order — a
+    // content hash — and there are ~90 of them, so with the default page of 50
+    // whether `load` shows up is decided by hashes: any edit anywhere in
+    // rmc-graph reshuffles the page and this test fails for no reason related
+    // to what it checks.
     let imports = get_imports(GraphImportsParams {
         directory: manifest_dir.to_string(),
         module: "rmc_graph::graph".to_string(),
-        pagination: ListPaginationParams::default(),
+        pagination: ListPaginationParams {
+            limit: Some(1000),
+            ..ListPaginationParams::default()
+        },
     })
     .await
     .expect("get_imports");

--- a/crates/rmc-server/src/tools/mod.rs
+++ b/crates/rmc-server/src/tools/mod.rs
@@ -1,6 +1,7 @@
 // Phase 1: Modular structure
 mod endpoints;
 mod params;
+mod paths;
 mod router;
 
 // Hypergraph (Layer 7): MCP tools backed by the persisted graph snapshot.

--- a/crates/rmc-server/src/tools/paths.rs
+++ b/crates/rmc-server/src/tools/paths.rs
@@ -48,8 +48,8 @@ mod tests {
 
     #[test]
     fn an_absolute_path_passes_through_unchanged() {
-        let got = require_absolute("directory", "/home/sc/t/bur/rust_app").unwrap();
-        assert_eq!(got, PathBuf::from("/home/sc/t/bur/rust_app"));
+        let got = require_absolute("directory", "/home/user/projects/example").unwrap();
+        assert_eq!(got, PathBuf::from("/home/user/projects/example"));
     }
 
     #[test]
@@ -76,7 +76,7 @@ mod tests {
 
     #[test]
     fn a_tilde_path_is_refused_with_the_reason_it_looks_absolute() {
-        let err = require_absolute("directory", "~/t/bur/rust_app").unwrap_err();
+        let err = require_absolute("directory", "~/projects/example").unwrap_err();
         assert!(err.message.contains("not expanded"), "{}", err.message);
     }
 }

--- a/crates/rmc-server/src/tools/paths.rs
+++ b/crates/rmc-server/src/tools/paths.rs
@@ -1,0 +1,82 @@
+//! One gate for every path parameter that arrives from a client.
+//!
+//! The daemon serves *every* working directory from a single process (its key
+//! stopped including the cwd), so it no longer shares a cwd with the session
+//! that asked. A relative path therefore resolves against whatever directory
+//! happened to spawn the daemon — which answers about the wrong project
+//! *silently*, with a plausible-looking result rather than an error. That is
+//! the most expensive failure class here, so relative paths are refused at the
+//! entry points instead of being resolved against a directory nobody chose.
+
+use std::path::{Path, PathBuf};
+
+use rmcp::ErrorData as McpError;
+
+/// Accept an absolute path parameter, refuse anything else.
+///
+/// `param` names the field in the refusal so the caller can see *which* of a
+/// tool's several path arguments was wrong. Takes `AsRef<Path>` because the
+/// entry points hold the value as a `&str` in some tools and as a `&Path` in
+/// others, and one gate is worth more than a tidy signature.
+pub(crate) fn require_absolute(param: &str, raw: impl AsRef<Path>) -> Result<PathBuf, McpError> {
+    let path = raw.as_ref();
+    if path.is_absolute() {
+        return Ok(path.to_path_buf());
+    }
+
+    let shown = path.display();
+    // `~` is worth naming: shells expand it, JSON does not, so a tilde path
+    // arrives here looking absolute to a human and relative to the filesystem.
+    let hint = if path.to_string_lossy().starts_with('~') {
+        " (`~` is not expanded — pass the expanded home directory)"
+    } else {
+        ""
+    };
+    Err(McpError::invalid_params(
+        format!(
+            "`{param}` must be an absolute path, got `{shown}`{hint}. \
+             One daemon serves every working directory, so it cannot resolve \
+             a relative path on your behalf."
+        ),
+        None,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_absolute_path_passes_through_unchanged() {
+        let got = require_absolute("directory", "/home/sc/t/bur/rust_app").unwrap();
+        assert_eq!(got, PathBuf::from("/home/sc/t/bur/rust_app"));
+    }
+
+    #[test]
+    fn a_relative_path_is_refused() {
+        for raw in [".", "..", "crates/rmc-server", "./x", ""] {
+            let err = require_absolute("directory", raw)
+                .expect_err("a relative path must not be accepted");
+            assert!(
+                err.message.contains("must be an absolute path"),
+                "unhelpful refusal for {raw:?}: {}",
+                err.message
+            );
+        }
+    }
+
+    /// The refusal has to name the offending parameter: several tools take more
+    /// than one path, and "some path was relative" would send the caller hunting.
+    #[test]
+    fn the_refusal_names_the_parameter_and_the_value() {
+        let err = require_absolute("file_path", "src/main.rs").unwrap_err();
+        assert!(err.message.contains("file_path"), "{}", err.message);
+        assert!(err.message.contains("src/main.rs"), "{}", err.message);
+    }
+
+    #[test]
+    fn a_tilde_path_is_refused_with_the_reason_it_looks_absolute() {
+        let err = require_absolute("directory", "~/t/bur/rust_app").unwrap_err();
+        assert!(err.message.contains("not expanded"), "{}", err.message);
+    }
+}

--- a/crates/rmc-server/src/tools/router.rs
+++ b/crates/rmc-server/src/tools/router.rs
@@ -790,7 +790,7 @@ impl ServerHandler for SearchToolRouter {
                 .enable_tools()
                 .build(),
             server_info: Implementation::from_build_env(),
-            instructions: Some("Rust code intelligence server for searching code, reading files, resolving symbols and references, previewing renames, inspecting dependencies and call graphs, semantic similarity, persisted hypergraph queries, workspace audits, and cache/index maintenance. List-shaped graph and audit tools accept `limit` (default 50), `offset`, and `summary`; responses include `total_match_count` plus returned-count metadata. See each tool's description for parameters and limitations; run `build_hypergraph` before graph-backed tools that require it."
+            instructions: Some("Rust code intelligence server for searching code, reading files, resolving symbols and references, previewing renames, inspecting dependencies and call graphs, semantic similarity, persisted hypergraph queries, workspace audits, and cache/index maintenance. Every path parameter (`directory`, `file_path`, …) must be ABSOLUTE: one daemon serves every working directory, so it shares no cwd with your session and will refuse a relative path rather than resolve it against a directory nobody chose. List-shaped graph and audit tools accept `limit` (default 50), `offset`, and `summary`; responses include `total_match_count` plus returned-count metadata. See each tool's description for parameters and limitations; run `build_hypergraph` before graph-backed tools that require it."
                 .into(),
             ),
         }

--- a/crates/rust-code-mcp/Cargo.toml
+++ b/crates/rust-code-mcp/Cargo.toml
@@ -15,6 +15,8 @@ tracing-subscriber = { workspace = true }
 fs2 = "0.4"
 # Socket key (project + env + binary identity).
 sha2 = { workspace = true }
+# The global allocator behind the `mimalloc` feature — see its comment below.
+mimalloc = { version = "0.1", optional = true }
 
 [dev-dependencies]
 # Examples and integration tests moved here with the executable package, so they
@@ -76,3 +78,15 @@ embedded = []
 # GPU/CUDA embeddings (qwen3 reranker via candle). Requires nvcc/CUDA toolkit at build time.
 # Default build is CPU-only; opt in with `cargo build --release --features cuda`.
 cuda = ["rmc-server/cuda"]
+# mimalloc as the global allocator instead of the system one.
+#
+# Why: glibc does not return arenas fragmented by rust-analyzer's salsa database
+# to the kernel — a daemon with an EMPTY runtime still held 4.9 GB (the
+# measurement and the numbers are in `rmc_server::mcp::memory`). mimalloc gives
+# memory back on its own, by decay, and can be told to collect on demand.
+#
+# Why mimalloc and not jemalloc: `tikv-jemalloc-sys` does not build on Windows,
+# and the server is needed there too. A feature rather than a default, because
+# replacing the global allocator is a deployment-level decision and its price on
+# a given machine should be measured, not inherited silently.
+mimalloc = ["dep:mimalloc", "rmc-server/mimalloc"]

--- a/crates/rust-code-mcp/Cargo.toml
+++ b/crates/rust-code-mcp/Cargo.toml
@@ -7,9 +7,14 @@ edition = "2024"
 rmc-server = { path = "../rmc-server" }
 
 rmcp = { workspace = true }
-tokio = { workspace = true }
+# net/time/io-util drive the shared-daemon transport (unix socket, spawn wait, proxy).
+tokio = { workspace = true, features = ["net", "time", "io-util"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+# Lock around "spawn the daemon": without it two simultaneous sessions spawn two.
+fs2 = "0.4"
+# Socket key (project + env + binary identity).
+sha2 = { workspace = true }
 
 [dev-dependencies]
 # Examples and integration tests moved here with the executable package, so they

--- a/crates/rust-code-mcp/src/daemon.rs
+++ b/crates/rust-code-mcp/src/daemon.rs
@@ -178,8 +178,8 @@ Env: RMC_DAEMON=0 forces in-process; RMC_DAEMON_DIR sets the socket directory;
      RMC_DAEMON_IDLE_SECS is the same as --idle-secs.
 
 Memory watchdog (daemon only; 0 disables a threshold):
-  RMC_RSS_SOFT_MB=4096       unload the analysis contexts above this RSS
-  RMC_RSS_HARD_MB=10240      above this, retire: stop taking new clients, let
+  RMC_RSS_SOFT_MB=8192       unload the analysis contexts above this RSS
+  RMC_RSS_HARD_MB=16384      above this, retire: stop taking new clients, let
                              the current ones finish, exit — a successor is
                              started on demand, so no session is cut off
   RMC_RSS_COOLDOWN_SECS=300  minimum gap between two unloads
@@ -241,14 +241,24 @@ pub struct WatchdogLimits {
     pub cooldown: Duration,
 }
 
-/// Four gigabytes: comfortably above the honest cost of one loaded workspace
-/// (~2-3 GB for a `Fast` load of a large repo, measured on `bur/rust_app`), so
-/// ordinary work never trips it, and far below the point where the machine
-/// starts swapping.
-const DEFAULT_RSS_SOFT_MB: u64 = 4096;
-/// Ten gigabytes: past this, unloading has already been tried and the memory is
-/// stuck in the allocator, so only a fresh process gets it back.
-const DEFAULT_RSS_HARD_MB: u64 = 10240;
+/// Eight gigabytes, and the number comes from a measurement rather than a guess.
+///
+/// A freshly started daemon that has done *nothing* — no project loaded, no
+/// query answered — already sits at **2.3 GB**: the ONNX runtime, the embedding
+/// model and the GPU probe are paid for at startup. One `Fast`-loaded workspace
+/// of ~4000 files adds ~3 GB, which is why a healthy daemon serving
+/// `bur/rust_app` measures ~5.3 GB.
+///
+/// So the ordinary working point is above 5 GB, and the first draft of this
+/// constant — 4 GB, picked from the workspace cost alone and forgetting the
+/// fixed 2.3 GB floor — sat *below* normal. It would have unloaded
+/// rust-analyzer every cooldown on a perfectly healthy daemon: a memory guard
+/// that does nothing but make every query reload the workspace.
+const DEFAULT_RSS_SOFT_MB: u64 = 8192;
+/// Sixteen gigabytes: past this, unloading has already been tried and the memory
+/// is stuck in the allocator, so only a fresh process gets it back. Three times
+/// the healthy working point, and well under the 25 GB that prompted this work.
+const DEFAULT_RSS_HARD_MB: u64 = 16384;
 /// Five minutes between unloads. Without a floor the watchdog would unload on
 /// every tick — RSS usually does *not* drop after an unload (see
 /// `rmc_server::mcp::memory`), so the trigger stays true and the next tick would
@@ -829,6 +839,36 @@ mod watchdog_tests {
         assert_eq!(
             decide_watchdog_action(99000, disabled, None, false),
             WatchdogAction::None
+        );
+    }
+
+    /// A healthy daemon serving one large workspace, measured live: 2.3 GB of
+    /// fixed startup cost (ONNX runtime, embedding model, GPU probe) plus ~3 GB
+    /// for a `Fast` load of ~4000 files.
+    const MEASURED_HEALTHY_MB: u64 = 5300;
+
+    /// The defect this closes: the first `DEFAULT_RSS_SOFT_MB` was 4096, chosen
+    /// from the workspace cost alone and forgetting the fixed startup floor —
+    /// below the normal working point, so a healthy daemon would have unloaded
+    /// rust-analyzer on every cooldown forever. A default that fires during
+    /// ordinary work is worse than no watchdog at all.
+    #[test]
+    fn defaults_do_not_fire_on_a_healthy_daemon() {
+        let defaults = WatchdogLimits {
+            soft_mb: DEFAULT_RSS_SOFT_MB,
+            hard_mb: DEFAULT_RSS_HARD_MB,
+            cooldown: Duration::from_secs(DEFAULT_RSS_COOLDOWN_SECS),
+        };
+
+        assert_eq!(
+            decide_watchdog_action(MEASURED_HEALTHY_MB, defaults, None, false),
+            WatchdogAction::None,
+            "a daemon at the measured healthy working point ({MEASURED_HEALTHY_MB} MB) must be \
+             left alone; soft limit is {DEFAULT_RSS_SOFT_MB} MB"
+        );
+        assert!(
+            DEFAULT_RSS_HARD_MB > DEFAULT_RSS_SOFT_MB,
+            "retiring before unloading has even been tried inverts the escalation"
         );
     }
 

--- a/crates/rust-code-mcp/src/daemon.rs
+++ b/crates/rust-code-mcp/src/daemon.rs
@@ -208,9 +208,9 @@ against a directory nobody chose.
 
 Memory watchdog (daemon only; 0 disables a threshold):
   RMC_RSS_SOFT_MB=12288      unload the analysis contexts above this RSS
-  RMC_RSS_HARD_MB=20480      above this, retire: stop taking new clients, let
-                             the current ones finish, exit — a successor is
-                             started on demand, so no session is cut off
+  RMC_RSS_HARD_MB=28672      above this, retire: stop taking new clients,
+                             unload contexts, let the current clients finish;
+                             a successor is started on demand
   RMC_RSS_COOLDOWN_SECS=300  minimum gap between two unloads
   RMC_MIN_AVAILABLE_MB=6144  unload when the MACHINE has less than this free,
                              whatever this daemon's own RSS is — the only
@@ -222,6 +222,11 @@ Memory watchdog (daemon only; 0 disables a threshold):
                              evict anything at all
   RMC_MAX_PROJECTS=3         how many analysis contexts stay loaded; past the
                              cap the least recently used one is dropped
+
+Index durability (0 disables the guard):
+  RMC_MIN_INDEX_FREE_MB=2048 refuse persistent index writes below this much
+                             free disk space; failed files remain queued in
+                             the Merkle snapshot for the next sync
 ";
 
 fn daemon_disabled() -> bool {
@@ -260,7 +265,7 @@ pub enum WatchdogAction {
     /// will give back. Costs the next semantic query a reload (~1.5 s for a
     /// `Fast` load of a 4000-file workspace), which is why it is rate-limited.
     Unload,
-    /// Unloading cannot fix this one: retire the daemon.
+    /// Retire the daemon and immediately unload its analysis contexts.
     ///
     /// Retiring is *not* killing the connections. The socket file is unlinked,
     /// so new clients no longer find this daemon and start a fresh one, while
@@ -271,7 +276,7 @@ pub enum WatchdogAction {
     /// failure we are trying to avoid.
     ///
     /// The waiting is bounded, and it has to be — see [`retire_grace_expired`].
-    Retire,
+    RetireAndUnload,
 }
 
 /// Thirty minutes, deliberately the same number as [`DEFAULT_IDLE_SECS`].
@@ -289,7 +294,7 @@ const DEFAULT_RETIRE_GRACE_SECS: u64 = 1800;
 ///
 /// # Why the wait needs an end at all
 ///
-/// [`WatchdogAction::Retire`] hands the socket to a successor and then waits for
+/// [`WatchdogAction::RetireAndUnload`] hands the socket to a successor and then waits for
 /// `live == 0`. That wait is unbounded, and its length is decided by something
 /// the daemon does not control: how long a client session lasts. A Claude Code
 /// session runs for hours, so the mechanism meant to *free* memory produced its
@@ -346,11 +351,17 @@ pub struct WatchdogLimits {
 /// them held between them on the machine that prompted this, and unlike that
 /// fleet it is a number something actually enforces.
 const DEFAULT_RSS_SOFT_MB: u64 = 12288;
-/// Twenty gigabytes: past this, unloading has already been tried and the memory
-/// is stuck in the allocator, so only a fresh process gets it back. Kept at a
-/// ratio to the soft limit rather than at a fixed distance — the escalation
-/// wants room for a peak above the working point, not a constant.
-const DEFAULT_RSS_HARD_MB: u64 = 20480;
+/// Twenty-eight gigabytes: past this, unloading has already been tried and the
+/// memory is stuck in the allocator, so only a fresh process gets it back.
+///
+/// The previous 20 GiB default sat inside the measured 15--22 GiB working range
+/// of one `Full` rust-analyzer context and retired a healthy daemon three times
+/// in two hours. `Full` is required for complete cross-crate and `#[cfg(test)]`
+/// reference answers, so the hard limit must leave that normal peak alone. The
+/// 12 GiB soft limit still unloads first; 28 GiB keeps a sizeable escalation
+/// gap while the machine-wide availability floor remains the final guard when
+/// other processes consume the RAM.
+const DEFAULT_RSS_HARD_MB: u64 = 28672;
 /// Five minutes between unloads. Without a floor the watchdog would unload on
 /// every tick — RSS usually does *not* drop after an unload (see
 /// `rmc_server::mcp::memory`), so the trigger stays true and the next tick would
@@ -471,7 +482,7 @@ pub fn decide_watchdog_action(
     // reclaims salsa memos, not the database — so the logs read "collected
     // garbage" every five minutes while nothing came back.
     if !retiring && limits.hard_mb > 0 && rss_mb >= limits.hard_mb {
-        return WatchdogAction::Retire;
+        return WatchdogAction::RetireAndUnload;
     }
 
     let over_own_limit = limits.soft_mb > 0 && rss_mb >= limits.soft_mb;
@@ -829,6 +840,38 @@ fn now_secs() -> i64 {
         .unwrap_or(0)
 }
 
+async fn unload_analysis_contexts(
+    runtime: &ServerRuntime,
+    retiring: bool,
+    rss_mb: u64,
+    available_mb: Option<u64>,
+    limits: WatchdogLimits,
+) {
+    tracing::warn!(
+        "unloading analysis contexts{}: RSS {} MB (soft limit {} MB), \
+         machine has {:?} MB available (floor {} MB)",
+        if retiring { " (retired, draining)" } else { "" },
+        rss_mb,
+        limits.soft_mb,
+        available_mb,
+        limits.min_available_mb
+    );
+    let report = runtime
+        .state()
+        .clear(RuntimeClearRequest {
+            scope: RuntimeClearScope::SemanticOnly,
+            workspace: None,
+        })
+        .await;
+    tracing::warn!(
+        "unloaded {} project(s); RSS {:?} -> {:?} KiB, {:?} KiB released",
+        report.semantic_projects_cleared,
+        report.memory.rss_kib_before,
+        report.memory.rss_kib_after,
+        report.memory.released_kib,
+    );
+}
+
 /// Daemon: listen on the socket, serve every connection from one `RuntimeState`.
 pub async fn run_daemon(
     socket: &Path,
@@ -957,38 +1000,12 @@ pub async fn run_daemon(
                     // `retiring` is named too: a retired daemon unloading at 21 GB
                     // reads as a broken soft limit unless the line says which
                     // daemon it came from, and both daemons write to one log file.
-                    tracing::warn!(
-                        "unloading analysis contexts{}: RSS {} MB (soft limit {} MB), \
-                         machine has {:?} MB available (floor {} MB)",
-                        if retiring { " (retired, draining)" } else { "" },
-                        rss_mb,
-                        limits.soft_mb,
-                        available_mb,
-                        limits.min_available_mb
-                    );
-                    let report = runtime
-                        .state()
-                        .clear(RuntimeClearRequest {
-                            scope: RuntimeClearScope::SemanticOnly,
-                            workspace: None,
-                        })
-                        .await;
+                    unload_analysis_contexts(runtime, retiring, rss_mb, available_mb, limits).await;
                     last_unload = Some(SystemTime::now());
-                    // Report what the release actually achieved, not that it
-                    // ran. On glibc this line is routinely "0 MB released",
-                    // and that fact belongs in the log rather than in a later
-                    // investigation.
-                    tracing::warn!(
-                        "unloaded {} project(s); RSS {:?} -> {:?} KiB, {:?} KiB released",
-                        report.semantic_projects_cleared,
-                        report.memory.rss_kib_before,
-                        report.memory.rss_kib_after,
-                        report.memory.released_kib,
-                    );
                 }
-                WatchdogAction::Retire => {
+                WatchdogAction::RetireAndUnload => {
                     tracing::warn!(
-                        "RSS {} MB is over the {} MB hard limit; retiring: new clients will start a fresh daemon, current ones finish here",
+                        "RSS {} MB is over the {} MB hard limit; retiring and unloading analysis contexts: new clients will start a fresh daemon, current ones finish here",
                         rss_mb,
                         limits.hard_mb
                     );
@@ -998,6 +1015,13 @@ pub async fn run_daemon(
                     let _ = fs::remove_file(socket);
                     retiring = true;
                     retiring_since = Some(SystemTime::now());
+                    // Retirement changes the economics of unloading: the
+                    // daemon accepts no new work and a successor is about to
+                    // load its own context. Do not carry an old five-minute
+                    // cooldown into that state; release the retired daemon's
+                    // contexts on this very tick.
+                    unload_analysis_contexts(runtime, true, rss_mb, available_mb, limits).await;
+                    last_unload = Some(SystemTime::now());
                 }
             }
         }
@@ -1117,7 +1141,7 @@ mod watchdog_tests {
     fn the_hard_limit_outranks_the_cooldown() {
         assert_eq!(
             decide_watchdog_action(11000, ROOMY, LIMITS, Some(Duration::from_secs(1)), false),
-            WatchdogAction::Retire
+            WatchdogAction::RetireAndUnload
         );
     }
 
@@ -1127,7 +1151,7 @@ mod watchdog_tests {
     fn a_retiring_daemon_never_retires_again() {
         assert_ne!(
             decide_watchdog_action(11000, ROOMY, LIMITS, None, true),
-            WatchdogAction::Retire
+            WatchdogAction::RetireAndUnload
         );
     }
 
@@ -1234,7 +1258,13 @@ mod watchdog_tests {
     #[test]
     fn the_floor_respects_the_cooldown() {
         assert_eq!(
-            decide_watchdog_action(3000, Some(2000), LIMITS, Some(Duration::from_secs(60)), false),
+            decide_watchdog_action(
+                3000,
+                Some(2000),
+                LIMITS,
+                Some(Duration::from_secs(60)),
+                false
+            ),
             WatchdogAction::None
         );
     }
@@ -1302,6 +1332,25 @@ mod watchdog_tests {
         );
     }
 
+    /// A complete cross-crate/reference query requires the measured `Full`
+    /// context. The old 20 GiB default sat inside this normal range and retired
+    /// a healthy daemon repeatedly.
+    #[test]
+    fn defaults_do_not_retire_at_the_measured_full_context_peak() {
+        const MEASURED_FULL_PEAK_MB: u64 = 22 * 1024;
+        let defaults = WatchdogLimits {
+            soft_mb: DEFAULT_RSS_SOFT_MB,
+            hard_mb: DEFAULT_RSS_HARD_MB,
+            min_available_mb: DEFAULT_MIN_AVAILABLE_MB,
+            cooldown: Duration::from_secs(DEFAULT_RSS_COOLDOWN_SECS),
+        };
+
+        assert_ne!(
+            decide_watchdog_action(MEASURED_FULL_PEAK_MB, ROOMY, defaults, None, false),
+            WatchdogAction::RetireAndUnload
+        );
+    }
+
     /// The machine-wide floor has to sit above where an OOM killer starts
     /// choosing victims, or it only ever fires after something has been killed —
     /// which is not a guard. `earlyoom -m 8,4` on a 61 GB desktop kills near
@@ -1327,7 +1376,7 @@ mod watchdog_tests {
         );
         assert_eq!(
             decide_watchdog_action(10240, ROOMY, LIMITS, None, false),
-            WatchdogAction::Retire
+            WatchdogAction::RetireAndUnload
         );
     }
 

--- a/crates/rust-code-mcp/src/daemon.rs
+++ b/crates/rust-code-mcp/src/daemon.rs
@@ -36,7 +36,10 @@
 //! point of failure.
 
 use fs2::FileExt;
-use rmc_server::mcp::{BACKGROUND_SYNC_ENV, RuntimeState, ServerRuntime};
+use rmc_server::mcp::{
+    BACKGROUND_SYNC_ENV, RuntimeClearRequest, RuntimeClearScope, RuntimeState, ServerRuntime,
+    rss_kib,
+};
 use rmc_server::tools::SearchTool;
 use rmcp::ServiceExt;
 use sha2::{Digest, Sha256};
@@ -63,6 +66,14 @@ pub const DAEMON_ENV: &str = "RMC_DAEMON";
 pub const DAEMON_DIR_ENV: &str = "RMC_DAEMON_DIR";
 /// How long a daemon stays alive with no clients, in seconds. `0` means forever.
 pub const IDLE_ENV: &str = "RMC_DAEMON_IDLE_SECS";
+/// RSS above which the daemon unloads its rust-analyzer contexts, in MB.
+/// `0` disables the check.
+pub const RSS_SOFT_ENV: &str = "RMC_RSS_SOFT_MB";
+/// RSS above which unloading is judged hopeless and the daemon retires itself,
+/// in MB. `0` disables the check.
+pub const RSS_HARD_ENV: &str = "RMC_RSS_HARD_MB";
+/// Minimum gap between two unloads, in seconds — see [`WatchdogAction`].
+pub const RSS_COOLDOWN_ENV: &str = "RMC_RSS_COOLDOWN_SECS";
 
 /// Env vars that change what the server computes, and therefore which daemon a
 /// client belongs to. Extend this list whenever a new behaviour-changing knob is
@@ -165,6 +176,13 @@ on demand.
 
 Env: RMC_DAEMON=0 forces in-process; RMC_DAEMON_DIR sets the socket directory;
      RMC_DAEMON_IDLE_SECS is the same as --idle-secs.
+
+Memory watchdog (daemon only; 0 disables a threshold):
+  RMC_RSS_SOFT_MB=4096       unload the analysis contexts above this RSS
+  RMC_RSS_HARD_MB=10240      above this, retire: stop taking new clients, let
+                             the current ones finish, exit — a successor is
+                             started on demand, so no session is cut off
+  RMC_RSS_COOLDOWN_SECS=300  minimum gap between two unloads
 ";
 
 fn daemon_disabled() -> bool {
@@ -183,6 +201,109 @@ fn idle_from_env() -> Duration {
         .and_then(|value| value.trim().parse::<u64>().ok())
         .unwrap_or(DEFAULT_IDLE_SECS);
     Duration::from_secs(secs)
+}
+
+/// What the memory watchdog decided to do this tick.
+///
+/// # Why a daemon needs one at all
+///
+/// Before the daemon, a leaking analysis was bounded by the session: the
+/// process died with its client. The daemon deliberately outlives clients, so
+/// nothing bounds it any more — `SemanticService` holds its contexts in a
+/// `HashMap` with no TTL and no eviction, and a workspace stays loaded until
+/// someone calls `clear_runtime` by hand. Which is to say: until an operator
+/// notices, which is exactly what "it just grows" means.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WatchdogAction {
+    /// Below the thresholds, or too soon after the last unload.
+    None,
+    /// Drop the loaded rust-analyzer contexts and return what the allocator
+    /// will give back. Costs the next semantic query a reload (~1.5 s for a
+    /// `Fast` load of a 4000-file workspace), which is why it is rate-limited.
+    Unload,
+    /// Unloading cannot fix this one: retire the daemon.
+    ///
+    /// Retiring is *not* killing the connections. The socket file is unlinked,
+    /// so new clients no longer find this daemon and start a fresh one, while
+    /// the clients already attached finish normally and the process exits when
+    /// the last of them leaves. A daemon that instead exited outright would
+    /// hand every attached session the `Connection closed` error that this
+    /// whole mechanism exists to prevent — a self-inflicted version of the
+    /// failure we are trying to avoid.
+    Retire,
+}
+
+/// Thresholds for [`decide_watchdog_action`], in MB. `0` disables a threshold.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WatchdogLimits {
+    pub soft_mb: u64,
+    pub hard_mb: u64,
+    pub cooldown: Duration,
+}
+
+/// Four gigabytes: comfortably above the honest cost of one loaded workspace
+/// (~2-3 GB for a `Fast` load of a large repo, measured on `bur/rust_app`), so
+/// ordinary work never trips it, and far below the point where the machine
+/// starts swapping.
+const DEFAULT_RSS_SOFT_MB: u64 = 4096;
+/// Ten gigabytes: past this, unloading has already been tried and the memory is
+/// stuck in the allocator, so only a fresh process gets it back.
+const DEFAULT_RSS_HARD_MB: u64 = 10240;
+/// Five minutes between unloads. Without a floor the watchdog would unload on
+/// every tick — RSS usually does *not* drop after an unload (see
+/// `rmc_server::mcp::memory`), so the trigger stays true and the next tick would
+/// fire again, reloading the workspace on every query and turning a memory
+/// guard into a performance disaster.
+const DEFAULT_RSS_COOLDOWN_SECS: u64 = 300;
+
+impl WatchdogLimits {
+    pub fn from_env() -> Self {
+        Self {
+            soft_mb: env_u64(RSS_SOFT_ENV, DEFAULT_RSS_SOFT_MB),
+            hard_mb: env_u64(RSS_HARD_ENV, DEFAULT_RSS_HARD_MB),
+            cooldown: Duration::from_secs(env_u64(RSS_COOLDOWN_ENV, DEFAULT_RSS_COOLDOWN_SECS)),
+        }
+    }
+}
+
+fn env_u64(name: &str, default: u64) -> u64 {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .unwrap_or(default)
+}
+
+/// Pure decision, so the policy can be judged by a test instead of by watching a
+/// daemon for an afternoon.
+///
+/// `since_unload` is `None` when nothing has been unloaded yet — the cooldown
+/// cannot bar the first attempt.
+pub fn decide_watchdog_action(
+    rss_mb: u64,
+    limits: WatchdogLimits,
+    since_unload: Option<Duration>,
+    retiring: bool,
+) -> WatchdogAction {
+    if retiring {
+        // Already on the way out; a second decision would only unlink a socket
+        // that by then may belong to our successor.
+        return WatchdogAction::None;
+    }
+
+    // Hard first: once memory is this high the unload has demonstrably not
+    // helped, and checking soft first would spend another cooldown finding out.
+    if limits.hard_mb > 0 && rss_mb >= limits.hard_mb {
+        return WatchdogAction::Retire;
+    }
+
+    if limits.soft_mb == 0 || rss_mb < limits.soft_mb {
+        return WatchdogAction::None;
+    }
+
+    match since_unload {
+        Some(elapsed) if elapsed < limits.cooldown => WatchdogAction::None,
+        _ => WatchdogAction::Unload,
+    }
 }
 
 /// Where sockets live. `$XDG_RUNTIME_DIR` is preferred: it is private, on tmpfs,
@@ -478,6 +599,21 @@ pub async fn run_daemon(
     let live = Arc::new(AtomicUsize::new(0));
     let idle_since = Arc::new(AtomicI64::new(now_secs()));
 
+    let limits = WatchdogLimits::from_env();
+    tracing::info!(
+        "memory watchdog: unload above {} MB, retire above {} MB, at most one unload per {:?} ({}/{}/{} to change; 0 disables)",
+        limits.soft_mb,
+        limits.hard_mb,
+        limits.cooldown,
+        RSS_SOFT_ENV,
+        RSS_HARD_ENV,
+        RSS_COOLDOWN_ENV,
+    );
+    let mut last_unload: Option<SystemTime> = None;
+    // Once retiring, the socket file is gone and belongs to whoever binds it
+    // next — this flag keeps the exit path from deleting a successor's socket.
+    let mut retiring = false;
+
     // Signals must reach the same exit path as an idle timeout. A daemon killed
     // outright leaves its socket file behind; clients survive that (they clear it
     // and start a new one), but `--print-socket` plus `ls` then point at an
@@ -523,6 +659,58 @@ pub async fn run_daemon(
             None => {}
         }
 
+        // Memory watchdog. Runs on the same tick as the idle check, so it costs
+        // one `/proc/self/status` read every 15 s and nothing else.
+        if let Some(rss_mb) = rss_kib().map(|kib| kib / 1024) {
+            let since_unload = last_unload.and_then(|at| at.elapsed().ok());
+            match decide_watchdog_action(rss_mb, limits, since_unload, retiring) {
+                WatchdogAction::None => {}
+                WatchdogAction::Unload => {
+                    tracing::warn!(
+                        "RSS {} MB is over the {} MB soft limit; unloading analysis contexts",
+                        rss_mb,
+                        limits.soft_mb
+                    );
+                    let report = runtime
+                        .state()
+                        .clear(RuntimeClearRequest {
+                            scope: RuntimeClearScope::SemanticOnly,
+                            workspace: None,
+                        })
+                        .await;
+                    last_unload = Some(SystemTime::now());
+                    // Report what the release actually achieved, not that it
+                    // ran. On glibc this line is routinely "0 MB released",
+                    // and that fact belongs in the log rather than in a later
+                    // investigation.
+                    tracing::warn!(
+                        "unloaded {} project(s); RSS {:?} -> {:?} KiB, {:?} KiB released",
+                        report.semantic_projects_cleared,
+                        report.memory.rss_kib_before,
+                        report.memory.rss_kib_after,
+                        report.memory.released_kib,
+                    );
+                }
+                WatchdogAction::Retire => {
+                    tracing::warn!(
+                        "RSS {} MB is over the {} MB hard limit; retiring: new clients will start a fresh daemon, current ones finish here",
+                        rss_mb,
+                        limits.hard_mb
+                    );
+                    // Unlinking is what makes this graceful: the address stops
+                    // resolving to us, so the next client spawns a successor,
+                    // while the connections already open keep working.
+                    let _ = fs::remove_file(socket);
+                    retiring = true;
+                }
+            }
+        }
+
+        if retiring && live.load(Ordering::SeqCst) == 0 {
+            tracing::info!("last client left after retiring; shutting down");
+            break;
+        }
+
         if !idle.is_zero()
             && live.load(Ordering::SeqCst) == 0
             && now_secs() - idle_since.load(Ordering::SeqCst) >= idle.as_secs() as i64
@@ -533,8 +721,11 @@ pub async fn run_daemon(
     }
 
     // Clean up, so the next client does not find a file, get refused, and spend a
-    // round trip clearing a stale socket.
-    let _ = fs::remove_file(socket);
+    // round trip clearing a stale socket. Skipped when retiring, where the file
+    // was already unlinked and any file at that path now belongs to a successor.
+    if !retiring {
+        let _ = fs::remove_file(socket);
+    }
     Ok(())
 }
 
@@ -545,6 +736,115 @@ async fn serve_connection(stream: UnixStream, state: RuntimeState) -> Result<(),
         .await?;
     service.waiting().await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod watchdog_tests {
+    use super::*;
+
+    const LIMITS: WatchdogLimits = WatchdogLimits {
+        soft_mb: 4096,
+        hard_mb: 10240,
+        cooldown: Duration::from_secs(300),
+    };
+
+    #[test]
+    fn ordinary_memory_use_is_left_alone() {
+        assert_eq!(
+            decide_watchdog_action(3000, LIMITS, None, false),
+            WatchdogAction::None
+        );
+    }
+
+    #[test]
+    fn crossing_the_soft_limit_unloads() {
+        assert_eq!(
+            decide_watchdog_action(5000, LIMITS, None, false),
+            WatchdogAction::Unload
+        );
+    }
+
+    /// The trigger normally stays true after an unload, because RSS does not
+    /// drop. Without the cooldown the watchdog would unload on every tick and
+    /// every semantic query would pay for a fresh workspace load.
+    #[test]
+    fn a_second_unload_waits_for_the_cooldown() {
+        assert_eq!(
+            decide_watchdog_action(5000, LIMITS, Some(Duration::from_secs(60)), false),
+            WatchdogAction::None
+        );
+        assert_eq!(
+            decide_watchdog_action(5000, LIMITS, Some(Duration::from_secs(600)), false),
+            WatchdogAction::Unload
+        );
+    }
+
+    /// Past the hard limit the cooldown must not delay retirement: unloading has
+    /// already been tried and the memory is stuck in the allocator.
+    #[test]
+    fn the_hard_limit_outranks_the_cooldown() {
+        assert_eq!(
+            decide_watchdog_action(11000, LIMITS, Some(Duration::from_secs(1)), false),
+            WatchdogAction::Retire
+        );
+    }
+
+    /// Deciding twice would unlink a socket that by then may belong to the
+    /// successor daemon.
+    #[test]
+    fn a_retiring_daemon_decides_nothing_further() {
+        assert_eq!(
+            decide_watchdog_action(11000, LIMITS, None, true),
+            WatchdogAction::None
+        );
+    }
+
+    #[test]
+    fn zero_disables_a_threshold() {
+        let no_soft = WatchdogLimits {
+            soft_mb: 0,
+            ..LIMITS
+        };
+        assert_eq!(
+            decide_watchdog_action(9000, no_soft, None, false),
+            WatchdogAction::None,
+            "soft_mb = 0 must not unload"
+        );
+
+        let no_hard = WatchdogLimits {
+            hard_mb: 0,
+            ..LIMITS
+        };
+        assert_eq!(
+            decide_watchdog_action(99000, no_hard, None, false),
+            WatchdogAction::Unload,
+            "hard_mb = 0 must never retire, however high RSS goes"
+        );
+
+        let disabled = WatchdogLimits {
+            soft_mb: 0,
+            hard_mb: 0,
+            ..LIMITS
+        };
+        assert_eq!(
+            decide_watchdog_action(99000, disabled, None, false),
+            WatchdogAction::None
+        );
+    }
+
+    /// Exactly at the limit counts as over it — a threshold that only fires
+    /// strictly above leaves a value that reads as tripped but does nothing.
+    #[test]
+    fn thresholds_are_inclusive() {
+        assert_eq!(
+            decide_watchdog_action(4096, LIMITS, None, false),
+            WatchdogAction::Unload
+        );
+        assert_eq!(
+            decide_watchdog_action(10240, LIMITS, None, false),
+            WatchdogAction::Retire
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/rust-code-mcp/src/daemon.rs
+++ b/crates/rust-code-mcp/src/daemon.rs
@@ -455,15 +455,22 @@ pub fn decide_watchdog_action(
     since_unload: Option<Duration>,
     retiring: bool,
 ) -> WatchdogAction {
-    if retiring {
-        // Already on the way out; a second decision would only unlink a socket
-        // that by then may belong to our successor.
-        return WatchdogAction::None;
-    }
-
     // Hard first: once memory is this high the unload has demonstrably not
     // helped, and checking soft first would spend another cooldown finding out.
-    if limits.hard_mb > 0 && rss_mb >= limits.hard_mb {
+    //
+    // A daemon that already retired may not retire again: the socket it would
+    // unlink by then belongs to its successor. Only *this* branch is barred to
+    // it, though — everything below is not only still allowed but is where it
+    // pays best. A retired daemon is past the hard limit by definition, serves
+    // no new clients, and holds its contexts purely for the sessions still
+    // draining; unloading touches no socket at all. Barring the whole function
+    // instead was the 2026-08-29 defect: RSS 21.6 GB sat untouched for the full
+    // `RMC_RETIRE_GRACE_SECS` next to a successor loading its own analysis, and
+    // between them they took this machine's 16 GB of swap to zero. Garbage
+    // collection kept running throughout and kept reporting success — it
+    // reclaims salsa memos, not the database — so the logs read "collected
+    // garbage" every five minutes while nothing came back.
+    if !retiring && limits.hard_mb > 0 && rss_mb >= limits.hard_mb {
         return WatchdogAction::Retire;
     }
 
@@ -947,9 +954,13 @@ pub async fn run_daemon(
                     // Which of the two reasons fired is worth naming: "RSS 3 GB,
                     // unloading" would read as a bug in the threshold rather
                     // than as the machine-wide floor doing its job.
+                    // `retiring` is named too: a retired daemon unloading at 21 GB
+                    // reads as a broken soft limit unless the line says which
+                    // daemon it came from, and both daemons write to one log file.
                     tracing::warn!(
-                        "unloading analysis contexts: RSS {} MB (soft limit {} MB), \
+                        "unloading analysis contexts{}: RSS {} MB (soft limit {} MB), \
                          machine has {:?} MB available (floor {} MB)",
+                        if retiring { " (retired, draining)" } else { "" },
                         rss_mb,
                         limits.soft_mb,
                         available_mb,
@@ -1110,12 +1121,52 @@ mod watchdog_tests {
         );
     }
 
-    /// Deciding twice would unlink a socket that by then may belong to the
+    /// Retiring twice would unlink a socket that by then belongs to the
     /// successor daemon.
     #[test]
-    fn a_retiring_daemon_decides_nothing_further() {
+    fn a_retiring_daemon_never_retires_again() {
+        assert_ne!(
+            decide_watchdog_action(11000, ROOMY, LIMITS, None, true),
+            WatchdogAction::Retire
+        );
+    }
+
+    /// And it is the one daemon that most needs to unload. It is past the hard
+    /// limit by definition, no new client will ever reach it, and its contexts
+    /// serve only the sessions still draining — while a successor is already
+    /// loading an analysis of its own beside it. On 2026-08-29 this returned
+    /// `None` and a retired daemon held 21.6 GB for the full grace period,
+    /// taking the machine's swap to zero.
+    #[test]
+    fn a_retiring_daemon_still_unloads() {
         assert_eq!(
             decide_watchdog_action(11000, ROOMY, LIMITS, None, true),
+            WatchdogAction::Unload
+        );
+    }
+
+    /// The rate limit is not lifted by retiring: an unload that just ran freed
+    /// what it was going to free, and repeating it every tick would only spend
+    /// the reload cost again on the sessions that are draining.
+    #[test]
+    fn a_retiring_daemon_still_respects_the_cooldown() {
+        assert_eq!(
+            decide_watchdog_action(11000, ROOMY, LIMITS, Some(Duration::from_secs(60)), true),
+            WatchdogAction::None
+        );
+        assert_eq!(
+            decide_watchdog_action(11000, ROOMY, LIMITS, Some(Duration::from_secs(600)), true),
+            WatchdogAction::Unload
+        );
+    }
+
+    /// Retiring is not itself a reason to unload — the thresholds still decide.
+    /// A daemon retired by the hard limit and since brought back under the soft
+    /// one by its own unload has nothing left to do but drain.
+    #[test]
+    fn a_retiring_daemon_below_the_limits_does_nothing() {
+        assert_eq!(
+            decide_watchdog_action(3000, ROOMY, LIMITS, None, true),
             WatchdogAction::None
         );
     }

--- a/crates/rust-code-mcp/src/daemon.rs
+++ b/crates/rust-code-mcp/src/daemon.rs
@@ -1,0 +1,647 @@
+//! One server per project: a unix-socket daemon plus a thin proxy client.
+//!
+//! # Why
+//!
+//! The stdio transport is 1:1 with its client by construction — one pipe, one
+//! process. Every editor window or agent session therefore spawned its own
+//! `rust-code-mcp`, and with it another `SemanticService` (the loaded
+//! rust-analyzer context for the workspace, ~2 GB) and another ONNX/GPU context.
+//! Measured on one developer machine: six live servers, 8.9 GB, all of them
+//! analyzing the same repository.
+//!
+//! The runtime state was already shareable and already partitioned by project:
+//! `RuntimeState` is a bundle of `Arc`s, `SemanticService` caches contexts in a
+//! `HashMap<PathBuf, ProjectContext>`, and locking is per workspace
+//! (`WorkspaceLockRegistry`) rather than global. The only missing piece was a
+//! transport that accepts more than one client.
+//!
+//! That is what this module adds: the daemon listens on a unix socket and serves
+//! each connection with its own `SearchToolRouter` on top of one shared
+//! `RuntimeState`. The client is the same binary with no arguments: it pumps
+//! stdin/stdout into the socket, and spawns the daemon if none is listening.
+//!
+//! # The socket key is more than the project
+//!
+//! It covers the working directory, the binary's size and mtime, and the env
+//! vars that change what the server computes. Otherwise a rebuilt binary — or a
+//! different configuration — would silently attach to a daemon that answers
+//! differently, and that reads as "the server is lying", not as "we connected to
+//! the wrong one".
+//!
+//! # A failing daemon never leaves a client without a server
+//!
+//! Any failure along connect / spawn / wait returns `Ok(false)` from
+//! [`run_client`], and the caller serves the session in-process exactly as it did
+//! before this module existed. The daemon is a memory optimisation, not a new
+//! point of failure.
+
+use fs2::FileExt;
+use rmc_server::mcp::{BACKGROUND_SYNC_ENV, RuntimeState, ServerRuntime};
+use rmc_server::tools::SearchTool;
+use rmcp::ServiceExt;
+use sha2::{Digest, Sha256};
+use std::fs::{self, File, OpenOptions};
+use std::io;
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::process::CommandExt;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicI64, AtomicUsize, Ordering};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tokio::io::{AsyncWriteExt, copy};
+use tokio::net::{UnixListener, UnixStream};
+use tokio::signal::unix::{SignalKind, signal};
+
+pub type BoxError = Box<dyn std::error::Error + Send + Sync>;
+
+/// Opt out of the whole scheme: `RMC_DAEMON=0` (`off`/`false`/`no`) keeps the
+/// server inside the client process, as it was before.
+pub const DAEMON_ENV: &str = "RMC_DAEMON";
+/// Directory holding sockets and daemon logs. Defaults to
+/// `$XDG_RUNTIME_DIR/rust-code-mcp`.
+pub const DAEMON_DIR_ENV: &str = "RMC_DAEMON_DIR";
+/// How long a daemon stays alive with no clients, in seconds. `0` means forever.
+pub const IDLE_ENV: &str = "RMC_DAEMON_IDLE_SECS";
+
+/// Env vars that change what the server computes, and therefore which daemon a
+/// client belongs to. Extend this list whenever a new behaviour-changing knob is
+/// added, or clients configured differently will end up sharing one server.
+const KEYED_ENV: [&str; 1] = [BACKGROUND_SYNC_ENV];
+
+/// Half an hour: long enough to survive a pause between questions in a session,
+/// short enough that a closed editor does not hold gigabytes until end of day.
+const DEFAULT_IDLE_SECS: u64 = 1800;
+/// Idle-check interval, and therefore the upper bound on how late the daemon
+/// exits after its last client leaves.
+const IDLE_TICK: Duration = Duration::from_secs(15);
+/// Upper bound on waiting for a daemon to come up. Deliberately generous, since
+/// startup may include model initialisation. The wait is not blind: if the
+/// process dies earlier, its exit status ends the wait instead of the timeout.
+const SPAWN_WAIT: Duration = Duration::from_secs(90);
+const SPAWN_POLL: Duration = Duration::from_millis(50);
+
+/// How this process was started. Resolved *before* the expensive startup: a
+/// client needs neither a `ServerRuntime` nor a background sync task — it is a pipe.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Mode {
+    /// Server inside this process over stdio — the behaviour before the daemon.
+    InProcess,
+    /// Daemon: listens on a socket, serves many clients from one `RuntimeState`.
+    Daemon { socket: PathBuf, idle: Duration },
+    /// Client: stdin/stdout ↔ socket, spawning the daemon when needed.
+    Client { socket: PathBuf },
+    /// `--print-socket`: print the resolved socket path and exit (diagnostics).
+    PrintSocket { socket: PathBuf },
+    /// `--help`.
+    Help,
+}
+
+/// Parse arguments and env. `args` excludes the program name.
+pub fn resolve_mode(args: &[String]) -> Result<Mode, BoxError> {
+    let mut socket: Option<PathBuf> = None;
+    let mut idle: Option<Duration> = None;
+    let mut explicit: Option<&str> = None;
+
+    let mut it = args.iter();
+    while let Some(arg) = it.next() {
+        match arg.as_str() {
+            "--help" | "-h" => return Ok(Mode::Help),
+            "--daemon" | "--client" | "--in-process" | "--print-socket" => {
+                if let Some(prev) = explicit {
+                    return Err(format!("modes {prev} and {arg} are mutually exclusive").into());
+                }
+                explicit = Some(match arg.as_str() {
+                    "--daemon" => "--daemon",
+                    "--client" => "--client",
+                    "--in-process" => "--in-process",
+                    _ => "--print-socket",
+                });
+            }
+            "--socket" => {
+                let value = it
+                    .next()
+                    .ok_or_else(|| BoxError::from("--socket requires a path"))?;
+                socket = Some(PathBuf::from(value));
+            }
+            "--idle-secs" => {
+                let value = it
+                    .next()
+                    .ok_or_else(|| BoxError::from("--idle-secs requires a number"))?;
+                idle = Some(Duration::from_secs(value.parse::<u64>()?));
+            }
+            other => return Err(format!("unknown argument {other}").into()),
+        }
+    }
+
+    let socket = match socket {
+        Some(path) => path,
+        None => default_socket_path()?,
+    };
+    let idle = idle.unwrap_or_else(idle_from_env);
+
+    Ok(match explicit {
+        Some("--daemon") => Mode::Daemon { socket, idle },
+        Some("--client") => Mode::Client { socket },
+        Some("--in-process") => Mode::InProcess,
+        Some("--print-socket") => Mode::PrintSocket { socket },
+        _ if daemon_disabled() => Mode::InProcess,
+        _ => Mode::Client { socket },
+    })
+}
+
+pub const USAGE: &str = "\
+rust-code-mcp — an MCP server for Rust codebases.
+
+With no arguments: a client of this project's shared daemon, which is started
+on demand.
+
+  --client            the same, explicitly
+  --daemon            become the daemon: listen on a socket, serve many clients
+  --in-process        run the server in this process over stdio (previous behaviour)
+  --print-socket      print this project's socket path and exit
+  --socket <PATH>     use this socket instead of the one derived from the project
+  --idle-secs <N>     daemon exits after N seconds with no clients (0 = never)
+
+Env: RMC_DAEMON=0 forces in-process; RMC_DAEMON_DIR sets the socket directory;
+     RMC_DAEMON_IDLE_SECS is the same as --idle-secs.
+";
+
+fn daemon_disabled() -> bool {
+    match std::env::var(DAEMON_ENV) {
+        Ok(value) => matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "0" | "off" | "false" | "no"
+        ),
+        Err(_) => false,
+    }
+}
+
+fn idle_from_env() -> Duration {
+    let secs = std::env::var(IDLE_ENV)
+        .ok()
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_IDLE_SECS);
+    Duration::from_secs(secs)
+}
+
+/// Where sockets live. `$XDG_RUNTIME_DIR` is preferred: it is private, on tmpfs,
+/// and cleaned out at logout together with any orphaned sockets.
+fn socket_dir() -> Result<PathBuf, BoxError> {
+    if let Ok(dir) = std::env::var(DAEMON_DIR_ENV) {
+        return Ok(PathBuf::from(dir));
+    }
+    if let Ok(runtime_dir) = std::env::var("XDG_RUNTIME_DIR") {
+        if !runtime_dir.is_empty() {
+            return Ok(PathBuf::from(runtime_dir).join("rust-code-mcp"));
+        }
+    }
+    let user = std::env::var("USER").unwrap_or_else(|_| "shared".to_string());
+    Ok(std::env::temp_dir().join(format!("rust-code-mcp-{user}")))
+}
+
+fn ensure_dir(dir: &Path) -> io::Result<()> {
+    fs::create_dir_all(dir)?;
+    // The socket is an entry point into analysing someone's code: owner only.
+    fs::set_permissions(dir, fs::Permissions::from_mode(0o700))
+}
+
+/// The daemon key: the project plus everything that changes what answers mean.
+///
+/// The binary contributes its size and mtime rather than a content hash: a
+/// rebuild must produce a *new* daemon (otherwise a client built from new code
+/// would be served by the old server), and reading tens of megabytes on every
+/// startup to establish that is not worth it.
+fn workspace_key() -> Result<String, BoxError> {
+    let cwd = std::env::current_dir()?;
+    let cwd = fs::canonicalize(&cwd).unwrap_or(cwd);
+
+    let exe = std::env::current_exe()?;
+    let exe_meta = fs::metadata(&exe).ok();
+    let exe_len = exe_meta.as_ref().map(|m| m.len()).unwrap_or(0);
+    let exe_mtime = exe_meta
+        .as_ref()
+        .and_then(|m| m.modified().ok())
+        .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+
+    let env: Vec<(&str, String)> = KEYED_ENV
+        .iter()
+        .map(|key| {
+            (
+                *key,
+                std::env::var(key).unwrap_or_else(|_| "<unset>".to_string()),
+            )
+        })
+        .collect();
+
+    Ok(key_from_parts(&cwd, &exe, exe_len, exe_mtime, &env))
+}
+
+/// The pure part of the key: everything that matters arrives as an argument.
+///
+/// Split out of [`workspace_key`] for testability rather than tidiness: checking
+/// "the key changes with configuration" through `set_var` means mutating global
+/// env in parallel with other tests, which fails for reasons unrelated to keys.
+fn key_from_parts(
+    cwd: &Path,
+    exe: &Path,
+    exe_len: u64,
+    exe_mtime: u128,
+    env: &[(&str, String)],
+) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(cwd.as_os_str().as_encoded_bytes());
+    hasher.update([0]);
+    hasher.update(exe.as_os_str().as_encoded_bytes());
+    hasher.update(exe_len.to_le_bytes());
+    hasher.update(exe_mtime.to_le_bytes());
+    for (key, value) in env {
+        hasher.update([0]);
+        hasher.update(key.as_bytes());
+        hasher.update(b"=");
+        hasher.update(value.as_bytes());
+    }
+
+    let digest = hasher.finalize();
+    digest[..8].iter().map(|b| format!("{b:02x}")).collect()
+}
+
+pub fn default_socket_path() -> Result<PathBuf, BoxError> {
+    Ok(socket_dir()?.join(format!("{}.sock", workspace_key()?)))
+}
+
+fn lock_path(socket: &Path) -> PathBuf {
+    socket.with_extension("lock")
+}
+
+fn log_path(socket: &Path) -> PathBuf {
+    socket.with_extension("log")
+}
+
+/// A file lock around "check / clear a stale socket / spawn / wait".
+///
+/// Without it, two sessions starting at the same moment both find no socket and
+/// both spawn a daemon — which is exactly the duplicated memory this module
+/// exists to remove.
+struct SpawnLock {
+    file: File,
+}
+
+impl SpawnLock {
+    fn acquire(path: &Path) -> io::Result<Self> {
+        let file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(path)?;
+        file.lock_exclusive()?;
+        Ok(Self { file })
+    }
+}
+
+impl Drop for SpawnLock {
+    fn drop(&mut self) {
+        let _ = FileExt::unlock(&self.file);
+    }
+}
+
+async fn try_connect(socket: &Path) -> Option<UnixStream> {
+    UnixStream::connect(socket).await.ok()
+}
+
+/// Client: serve this session through the shared daemon.
+///
+/// `Ok(true)` — the session ran through the daemon and finished. `Ok(false)` —
+/// no daemon could be reached or started, and the caller must serve the session
+/// itself, in-process.
+pub async fn run_client(socket: &Path) -> Result<bool, BoxError> {
+    if let Some(stream) = try_connect(socket).await {
+        tracing::info!("connected to shared daemon at {}", socket.display());
+        proxy(stream).await?;
+        return Ok(true);
+    }
+
+    if let Some(parent) = socket.parent() {
+        if let Err(e) = ensure_dir(parent) {
+            tracing::warn!("socket dir {} unusable: {e}", parent.display());
+            return Ok(false);
+        }
+    }
+
+    let lock = match SpawnLock::acquire(&lock_path(socket)) {
+        Ok(lock) => lock,
+        Err(e) => {
+            tracing::warn!("spawn lock unavailable: {e}; serving in-process");
+            return Ok(false);
+        }
+    };
+
+    // Re-check under the lock: a daemon may have come up while we waited for it.
+    let stream = match try_connect(socket).await {
+        Some(stream) => Some(stream),
+        None => {
+            // The socket file exists but refuses connections, so the daemon died
+            // without cleaning up. Remove it ourselves: binding over a live file
+            // fails with EADDRINUSE.
+            if socket.exists() {
+                let _ = fs::remove_file(socket);
+            }
+            match spawn_daemon(socket) {
+                Ok(child) => wait_for_daemon(socket, child).await,
+                Err(e) => {
+                    tracing::warn!("failed to spawn daemon: {e}; serving in-process");
+                    None
+                }
+            }
+        }
+    };
+    drop(lock);
+
+    match stream {
+        Some(stream) => {
+            proxy(stream).await?;
+            Ok(true)
+        }
+        None => Ok(false),
+    }
+}
+
+fn spawn_daemon(socket: &Path) -> io::Result<Child> {
+    let exe = std::env::current_exe()?;
+    let log = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(log_path(socket))?;
+
+    let mut cmd = Command::new(exe);
+    cmd.arg("--daemon")
+        .arg("--socket")
+        .arg(socket)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        // The daemon's stderr goes to a file next to the socket: otherwise the
+        // diagnostics of a shared process die with the session that spawned it.
+        .stderr(Stdio::from(log))
+        // Its own process group, so Ctrl-C in one client's session does not take
+        // down a server other sessions are using.
+        .process_group(0);
+    cmd.spawn()
+}
+
+/// Wait for the daemon to bind. Ends early if the process dies, so a failed
+/// startup costs a moment rather than the full timeout.
+async fn wait_for_daemon(socket: &Path, mut child: Child) -> Option<UnixStream> {
+    let deadline = tokio::time::Instant::now() + SPAWN_WAIT;
+    loop {
+        if let Some(stream) = try_connect(socket).await {
+            return Some(stream);
+        }
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                tracing::warn!(
+                    "daemon exited before accepting connections ({status}); see {}",
+                    log_path(socket).display()
+                );
+                return None;
+            }
+            Ok(None) => {}
+            Err(e) => {
+                tracing::warn!("cannot poll daemon process: {e}");
+                return None;
+            }
+        }
+        if tokio::time::Instant::now() >= deadline {
+            tracing::warn!("daemon did not come up in {:?}", SPAWN_WAIT);
+            let _ = child.kill();
+            return None;
+        }
+        tokio::time::sleep(SPAWN_POLL).await;
+    }
+}
+
+/// Pump stdin/stdout ↔ socket.
+///
+/// `select`, not `join`: the daemon is the side that closes the connection, and
+/// waiting for EOF on stdin after that would hang — it may never arrive.
+async fn proxy(stream: UnixStream) -> io::Result<()> {
+    let (mut from_daemon, mut to_daemon) = stream.into_split();
+    let mut stdin = tokio::io::stdin();
+    let mut stdout = tokio::io::stdout();
+
+    let upstream = async {
+        copy(&mut stdin, &mut to_daemon).await?;
+        to_daemon.shutdown().await
+    };
+    let downstream = async {
+        copy(&mut from_daemon, &mut stdout).await?;
+        stdout.flush().await
+    };
+
+    tokio::select! {
+        result = upstream => result,
+        result = downstream => result,
+    }
+}
+
+fn now_secs() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+/// Daemon: listen on the socket, serve every connection from one `RuntimeState`.
+pub async fn run_daemon(
+    socket: &Path,
+    idle: Duration,
+    runtime: &ServerRuntime,
+) -> Result<(), BoxError> {
+    if let Some(parent) = socket.parent() {
+        ensure_dir(parent)?;
+    }
+    let listener = UnixListener::bind(socket).map_err(|e| {
+        BoxError::from(format!(
+            "cannot bind {}: {e} (is a live daemon already holding it?)",
+            socket.display()
+        ))
+    })?;
+    tracing::info!(
+        "daemon listening on {} (idle timeout {:?})",
+        socket.display(),
+        idle
+    );
+
+    let live = Arc::new(AtomicUsize::new(0));
+    let idle_since = Arc::new(AtomicI64::new(now_secs()));
+
+    // Signals must reach the same exit path as an idle timeout. A daemon killed
+    // outright leaves its socket file behind; clients survive that (they clear it
+    // and start a new one), but `--print-socket` plus `ls` then point at an
+    // address where nobody listens — diagnostics lying exactly when consulted.
+    let mut sigterm = signal(SignalKind::terminate())?;
+    let mut sigint = signal(SignalKind::interrupt())?;
+
+    loop {
+        let accepted = tokio::select! {
+            accepted = listener.accept() => Some(accepted),
+            _ = tokio::time::sleep(IDLE_TICK) => None,
+            _ = sigterm.recv() => {
+                tracing::info!("SIGTERM, shutting down");
+                break;
+            }
+            _ = sigint.recv() => {
+                tracing::info!("SIGINT, shutting down");
+                break;
+            }
+        };
+
+        match accepted {
+            Some(Ok((stream, _addr))) => {
+                let state = runtime.state();
+                let live = Arc::clone(&live);
+                let idle_since = Arc::clone(&idle_since);
+                live.fetch_add(1, Ordering::SeqCst);
+                tracing::info!("client connected ({} live)", live.load(Ordering::SeqCst));
+                tokio::spawn(async move {
+                    if let Err(e) = serve_connection(stream, state).await {
+                        tracing::warn!("connection ended with error: {e}");
+                    }
+                    // The idle countdown starts when the *last* client leaves.
+                    if live.fetch_sub(1, Ordering::SeqCst) == 1 {
+                        idle_since.store(now_secs(), Ordering::SeqCst);
+                    }
+                });
+            }
+            Some(Err(e)) => {
+                tracing::error!("accept failed: {e}");
+                break;
+            }
+            None => {}
+        }
+
+        if !idle.is_zero()
+            && live.load(Ordering::SeqCst) == 0
+            && now_secs() - idle_since.load(Ordering::SeqCst) >= idle.as_secs() as i64
+        {
+            tracing::info!("no clients for {:?}, shutting down", idle);
+            break;
+        }
+    }
+
+    // Clean up, so the next client does not find a file, get refused, and spend a
+    // round trip clearing a stale socket.
+    let _ = fs::remove_file(socket);
+    Ok(())
+}
+
+async fn serve_connection(stream: UnixStream, state: RuntimeState) -> Result<(), BoxError> {
+    let (read_half, write_half) = stream.into_split();
+    let service = SearchTool::with_runtime_state(state)
+        .serve((read_half, write_half))
+        .await?;
+    service.waiting().await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mode_of(args: &[&str]) -> Mode {
+        let owned: Vec<String> = args.iter().map(|s| s.to_string()).collect();
+        resolve_mode(&owned).expect("mode")
+    }
+
+    #[test]
+    fn explicit_socket_wins_over_computed_key() {
+        let mode = mode_of(&["--daemon", "--socket", "/tmp/x.sock", "--idle-secs", "5"]);
+        assert_eq!(
+            mode,
+            Mode::Daemon {
+                socket: PathBuf::from("/tmp/x.sock"),
+                idle: Duration::from_secs(5),
+            }
+        );
+    }
+
+    #[test]
+    fn in_process_is_explicit_opt_out() {
+        assert_eq!(
+            mode_of(&["--in-process", "--socket", "/tmp/x.sock"]),
+            Mode::InProcess
+        );
+    }
+
+    #[test]
+    fn two_modes_at_once_are_rejected() {
+        let owned: Vec<String> = ["--daemon", "--client"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        assert!(resolve_mode(&owned).is_err());
+    }
+
+    #[test]
+    fn unknown_argument_is_rejected() {
+        let owned = vec!["--socks".to_string()];
+        assert!(resolve_mode(&owned).is_err());
+    }
+
+    fn key(cwd: &str, exe: &str, len: u64, mtime: u128, sync: &str) -> String {
+        key_from_parts(
+            Path::new(cwd),
+            Path::new(exe),
+            len,
+            mtime,
+            &[(BACKGROUND_SYNC_ENV, sync.to_string())],
+        )
+    }
+
+    #[test]
+    fn key_is_stable_for_same_inputs() {
+        assert_eq!(
+            key("/repo", "/bin/mcp", 10, 20, "1"),
+            key("/repo", "/bin/mcp", 10, 20, "1")
+        );
+    }
+
+    /// Configuration must split daemons: a server started with different
+    /// behaviour-changing env does not answer what the new client is asking for.
+    #[test]
+    fn key_depends_on_keyed_env() {
+        assert_ne!(
+            key("/repo", "/bin/mcp", 10, 20, "1"),
+            key("/repo", "/bin/mcp", 10, 20, "0")
+        );
+    }
+
+    /// Different projects, different daemons — otherwise "one per project" turns
+    /// into "one for everything".
+    #[test]
+    fn key_depends_on_project() {
+        assert_ne!(
+            key("/repo-a", "/bin/mcp", 10, 20, "1"),
+            key("/repo-b", "/bin/mcp", 10, 20, "1")
+        );
+    }
+
+    /// A rebuilt binary must get a new socket, or a client built from new code is
+    /// silently served by the old server.
+    #[test]
+    fn key_depends_on_binary_identity() {
+        assert_ne!(
+            key("/repo", "/bin/mcp", 10, 20, "1"),
+            key("/repo", "/bin/mcp", 10, 21, "1"),
+            "a different binary mtime means a different daemon"
+        );
+        assert_ne!(
+            key("/repo", "/bin/mcp", 10, 20, "1"),
+            key("/repo", "/bin/mcp", 11, 20, "1"),
+            "a different binary size means a different daemon"
+        );
+    }
+}

--- a/crates/rust-code-mcp/src/daemon.rs
+++ b/crates/rust-code-mcp/src/daemon.rs
@@ -330,8 +330,8 @@ pub struct WatchdogLimits {
 /// A freshly started daemon that has done *nothing* — no project loaded, no
 /// query answered — already sits at **2.3 GB**: the ONNX runtime, the embedding
 /// model and the GPU probe are paid for at startup. One `Fast`-loaded workspace
-/// of ~4000 files adds ~3 GB, which is why a healthy daemon serving
-/// `bur/rust_app` measures ~5.3 GB.
+/// of ~4000 files adds ~3 GB, which is why a healthy daemon serving one such
+/// workspace measures ~5.3 GB.
 ///
 /// So the ordinary working point is above 5 GB, and the first draft of this
 /// constant — 4 GB, picked from the workspace cost alone and forgetting the

--- a/crates/rust-code-mcp/src/daemon.rs
+++ b/crates/rust-code-mcp/src/daemon.rs
@@ -859,6 +859,17 @@ pub async fn run_daemon(
         RSS_HARD_ENV,
         RSS_COOLDOWN_ENV,
     );
+    // Announced separately because it answers a different question — the
+    // machine's free memory, not this process's size — and because a knob the
+    // daemon never names is a knob nobody knows to reach for. It also reports
+    // what it can actually see: on a platform without /proc the floor is dead,
+    // and that must be visible at startup rather than inferred from silence.
+    tracing::info!(
+        "machine memory floor: unload when less than {} MB is available, now {:?} MB ({} to change; 0 disables)",
+        limits.min_available_mb,
+        mem_available_kib().map(|kib| kib / 1024),
+        MIN_AVAILABLE_ENV,
+    );
     let retire_grace = retire_grace_from_env();
     tracing::info!(
         "retire deadline: a retired daemon exits after {:?} even with clients attached ({} to change; 0 waits forever)",

--- a/crates/rust-code-mcp/src/daemon.rs
+++ b/crates/rust-code-mcp/src/daemon.rs
@@ -77,6 +77,9 @@ pub const RSS_COOLDOWN_ENV: &str = "RMC_RSS_COOLDOWN_SECS";
 /// How long a retired daemon waits for its clients to leave before exiting
 /// anyway, in seconds. `0` means wait forever — see [`retire_grace_expired`].
 pub const RETIRE_GRACE_ENV: &str = "RMC_RETIRE_GRACE_SECS";
+/// How often the daemon collects garbage in its loaded analyses, in seconds.
+/// `0` disables it — see [`should_collect_garbage`].
+pub const GC_INTERVAL_ENV: &str = "RMC_GC_INTERVAL_SECS";
 
 /// Env vars that change what the server computes, and therefore which daemon a
 /// client belongs to. Extend this list whenever a new behaviour-changing knob is
@@ -319,6 +322,41 @@ impl WatchdogLimits {
             cooldown: Duration::from_secs(env_u64(RSS_COOLDOWN_ENV, DEFAULT_RSS_COOLDOWN_SECS)),
         }
     }
+}
+
+/// Five minutes — deliberately the same number as [`DEFAULT_RSS_COOLDOWN_SECS`],
+/// because it buys the same thing at the same price.
+///
+/// A collection makes the next query in each project slower (its memos have to
+/// be re-validated against a new revision) in exchange for memory. The cooldown
+/// is already this daemon's statement of how often it is willing to make that
+/// trade; a garbage collection is a far cheaper version of it than an unload, so
+/// there is no case for pacing it more eagerly than the expensive one.
+const DEFAULT_GC_INTERVAL_SECS: u64 = 300;
+
+/// Is it time to collect garbage in the loaded analyses?
+///
+/// # Why the daemon needs a timer for this at all
+///
+/// salsa evicts an LRU-capped query's memos only while bumping the revision, and
+/// a revision bumps when a file changes. rust-analyzer inside an editor gets
+/// those from typing; a project loaded into this daemon and then left alone gets
+/// none, so its LRU capacity — whatever it is set to — never evicts anything.
+/// The measured 14.6 GB daemon was mostly exactly that: contexts for directories
+/// no one had touched for hours. This timer is where the bumps come from
+/// instead, which is what makes the capacities in the rust-analyzer fork mean
+/// something here.
+///
+/// `interval` of zero disables collection.
+///
+/// The elapsed time is measured from daemon startup, so the first collection
+/// happens one interval in rather than on the first tick — before that there is
+/// usually nothing loaded to collect.
+pub fn should_collect_garbage(since_last_gc: Duration, interval: Duration) -> bool {
+    if interval.is_zero() {
+        return false;
+    }
+    since_last_gc >= interval
 }
 
 /// The retire deadline, read from the environment.
@@ -711,6 +749,13 @@ pub async fn run_daemon(
         retire_grace,
         RETIRE_GRACE_ENV,
     );
+    let gc_interval = Duration::from_secs(env_u64(GC_INTERVAL_ENV, DEFAULT_GC_INTERVAL_SECS));
+    tracing::info!(
+        "garbage collection: every {:?} in every loaded analysis ({} to change; 0 disables)",
+        gc_interval,
+        GC_INTERVAL_ENV,
+    );
+    let mut last_gc = SystemTime::now();
     let mut last_unload: Option<SystemTime> = None;
     // Once retiring, the socket file is gone and belongs to whoever binds it
     // next — this flag keeps the exit path from deleting a successor's socket.
@@ -808,6 +853,20 @@ pub async fn run_daemon(
                     retiring = true;
                     retiring_since = Some(SystemTime::now());
                 }
+            }
+        }
+
+        // Garbage collection, on its own timer rather than on the watchdog's
+        // thresholds: its job is to keep the working set from growing in the
+        // first place, so waiting for the soft limit would be waiting for the
+        // problem it prevents. Kept running while retiring too — a retired
+        // daemon can sit here for the whole grace period holding what pushed it
+        // over the hard limit.
+        if should_collect_garbage(last_gc.elapsed().unwrap_or_default(), gc_interval) {
+            let collected = runtime.state().collect_garbage().await;
+            last_gc = SystemTime::now();
+            if collected > 0 {
+                tracing::info!("collected garbage in {} loaded project(s)", collected);
             }
         }
 
@@ -1050,6 +1109,46 @@ mod watchdog_tests {
             DEFAULT_RETIRE_GRACE_SECS <= DEFAULT_IDLE_SECS,
             "a retired daemon outliving the idle timeout defeats the deadline: an idle daemon \
              would already have exited by then"
+        );
+    }
+
+    const GC_EVERY: Duration = Duration::from_secs(300);
+
+    /// The interval is a floor, so the tick that lands before it must not
+    /// collect: the daemon ticks every 15 s, and collecting on each of them
+    /// would re-validate every project's memos four times a minute.
+    #[test]
+    fn a_tick_inside_the_interval_does_not_collect() {
+        assert!(!should_collect_garbage(Duration::ZERO, GC_EVERY));
+        assert!(!should_collect_garbage(Duration::from_secs(299), GC_EVERY));
+    }
+
+    #[test]
+    fn the_interval_eventually_fires() {
+        assert!(should_collect_garbage(GC_EVERY, GC_EVERY));
+        assert!(should_collect_garbage(Duration::from_secs(3600), GC_EVERY));
+    }
+
+    /// Zero turns collection off. Needed because the collection is not free —
+    /// a daemon on a machine with memory to spare can decline to pay for it.
+    #[test]
+    fn a_zero_interval_never_collects() {
+        assert!(!should_collect_garbage(
+            Duration::from_secs(86400),
+            Duration::ZERO
+        ));
+    }
+
+    /// Collecting garbage and unloading contexts buy the same thing — memory in
+    /// exchange for a slower next query — and the collection is by far the
+    /// cheaper of the two. Pacing it more eagerly than the expensive one would
+    /// be backwards, and this is what says so out loud.
+    #[test]
+    fn collection_is_not_paced_more_eagerly_than_an_unload() {
+        assert!(
+            DEFAULT_GC_INTERVAL_SECS >= DEFAULT_RSS_COOLDOWN_SECS,
+            "a collection running more often than the unload cooldown would spend the cheap \
+             mechanism harder than the expensive one"
         );
     }
 }

--- a/crates/rust-code-mcp/src/daemon.rs
+++ b/crates/rust-code-mcp/src/daemon.rs
@@ -1,4 +1,4 @@
-//! One server per project: a unix-socket daemon plus a thin proxy client.
+//! One server per user: a unix-socket daemon plus a thin proxy client.
 //!
 //! # Why
 //!
@@ -20,13 +20,26 @@
 //! `RuntimeState`. The client is the same binary with no arguments: it pumps
 //! stdin/stdout into the socket, and spawns the daemon if none is listening.
 //!
-//! # The socket key is more than the project
+//! # The socket key is the configuration, not the directory
 //!
-//! It covers the working directory, the binary's size and mtime, and the env
-//! vars that change what the server computes. Otherwise a rebuilt binary — or a
-//! different configuration — would silently attach to a daemon that answers
-//! differently, and that reads as "the server is lying", not as "we connected to
-//! the wrong one".
+//! It covers the binary's size and mtime and the env vars that change what the
+//! server computes. Otherwise a rebuilt binary — or a different configuration —
+//! would silently attach to a daemon that answers differently, and that reads as
+//! "the server is lying", not as "we connected to the wrong one".
+//!
+//! It deliberately does *not* cover the working directory. It used to, and the
+//! result was one daemon per directory a session happened to start in: measured
+//! on this machine, 11 processes holding 12.5 GB between them, several of them
+//! analysing the same repository. The cwd never selected the project in the
+//! first place — every tool takes its `directory` as a parameter — so keying on
+//! it bought no isolation, only duplication.
+//!
+//! The consequence is that the daemon does not share a working directory with
+//! the session asking, and cannot resolve a relative path on its behalf. Path
+//! parameters are therefore required to be absolute
+//! (`rmc_server::tools::paths::require_absolute`), and the daemon is spawned in
+//! `/` so that anything slipping past that gate fails loudly instead of quietly
+//! answering about the wrong tree.
 //!
 //! # A failing daemon never leaves a client without a server
 //!
@@ -37,15 +50,15 @@
 
 use fs2::FileExt;
 use rmc_server::mcp::{
-    BACKGROUND_SYNC_ENV, RuntimeClearRequest, RuntimeClearScope, RuntimeState, ServerRuntime,
-    rss_kib,
+    BACKGROUND_SYNC_ENV, EMBEDDING_PROFILE_ENV, RuntimeClearRequest, RuntimeClearScope,
+    RuntimeState, ServerRuntime, mem_available_kib, rss_kib,
 };
 use rmc_server::tools::SearchTool;
 use rmcp::ServiceExt;
 use sha2::{Digest, Sha256};
 use std::fs::{self, File, OpenOptions};
 use std::io;
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
@@ -74,6 +87,9 @@ pub const RSS_SOFT_ENV: &str = "RMC_RSS_SOFT_MB";
 pub const RSS_HARD_ENV: &str = "RMC_RSS_HARD_MB";
 /// Minimum gap between two unloads, in seconds — see [`WatchdogAction`].
 pub const RSS_COOLDOWN_ENV: &str = "RMC_RSS_COOLDOWN_SECS";
+/// Machine-wide `MemAvailable` floor, in MB: below it the daemon unloads its
+/// contexts even when its own RSS is fine. `0` disables the check.
+pub const MIN_AVAILABLE_ENV: &str = "RMC_MIN_AVAILABLE_MB";
 /// How long a retired daemon waits for its clients to leave before exiting
 /// anyway, in seconds. `0` means wait forever — see [`retire_grace_expired`].
 pub const RETIRE_GRACE_ENV: &str = "RMC_RETIRE_GRACE_SECS";
@@ -84,7 +100,7 @@ pub const GC_INTERVAL_ENV: &str = "RMC_GC_INTERVAL_SECS";
 /// Env vars that change what the server computes, and therefore which daemon a
 /// client belongs to. Extend this list whenever a new behaviour-changing knob is
 /// added, or clients configured differently will end up sharing one server.
-const KEYED_ENV: [&str; 1] = [BACKGROUND_SYNC_ENV];
+const KEYED_ENV: [&str; 2] = [EMBEDDING_PROFILE_ENV, BACKGROUND_SYNC_ENV];
 
 /// Half an hour: long enough to survive a pause between questions in a session,
 /// short enough that a closed editor does not hold gigabytes until end of day.
@@ -176,19 +192,36 @@ on demand.
   --client            the same, explicitly
   --daemon            become the daemon: listen on a socket, serve many clients
   --in-process        run the server in this process over stdio (previous behaviour)
-  --print-socket      print this project's socket path and exit
-  --socket <PATH>     use this socket instead of the one derived from the project
+  --print-socket      print this configuration's socket path and exit
+  --socket <PATH>     use this socket instead of the one derived from the
+                      binary and the environment
   --idle-secs <N>     daemon exits after N seconds with no clients (0 = never)
 
 Env: RMC_DAEMON=0 forces in-process; RMC_DAEMON_DIR sets the socket directory;
      RMC_DAEMON_IDLE_SECS is the same as --idle-secs.
 
+One daemon serves EVERY working directory: the socket is keyed by this binary
+and the environment above, not by the directory a session starts in. Path
+parameters must therefore be absolute — the daemon shares no working directory
+with the session asking, and will refuse a relative path rather than resolve it
+against a directory nobody chose.
+
 Memory watchdog (daemon only; 0 disables a threshold):
-  RMC_RSS_SOFT_MB=8192       unload the analysis contexts above this RSS
-  RMC_RSS_HARD_MB=16384      above this, retire: stop taking new clients, let
+  RMC_RSS_SOFT_MB=12288      unload the analysis contexts above this RSS
+  RMC_RSS_HARD_MB=20480      above this, retire: stop taking new clients, let
                              the current ones finish, exit — a successor is
                              started on demand, so no session is cut off
   RMC_RSS_COOLDOWN_SECS=300  minimum gap between two unloads
+  RMC_MIN_AVAILABLE_MB=6144  unload when the MACHINE has less than this free,
+                             whatever this daemon's own RSS is — the only
+                             reading that sees pressure it did not cause
+  RMC_RETIRE_GRACE_SECS=1800 a retired daemon exits after this even with
+                             clients still attached (those connections drop)
+  RMC_GC_INTERVAL_SECS=300   how often loaded analyses are garbage-collected;
+                             this is also what makes salsa's LRU capacities
+                             evict anything at all
+  RMC_MAX_PROJECTS=3         how many analysis contexts stay loaded; past the
+                             cap the least recently used one is dropped
 ";
 
 fn daemon_disabled() -> bool {
@@ -286,6 +319,9 @@ pub fn retire_grace_expired(retiring_for: Option<Duration>, grace: Duration) -> 
 pub struct WatchdogLimits {
     pub soft_mb: u64,
     pub hard_mb: u64,
+    /// Machine-wide floor on `MemAvailable`. Below it the daemon unloads even
+    /// though its own RSS is fine — see [`DEFAULT_MIN_AVAILABLE_MB`].
+    pub min_available_mb: u64,
     pub cooldown: Duration,
 }
 
@@ -302,11 +338,19 @@ pub struct WatchdogLimits {
 /// fixed 2.3 GB floor — sat *below* normal. It would have unloaded
 /// rust-analyzer every cooldown on a perfectly healthy daemon: a memory guard
 /// that does nothing but make every query reload the workspace.
-const DEFAULT_RSS_SOFT_MB: u64 = 8192;
-/// Sixteen gigabytes: past this, unloading has already been tried and the memory
-/// is stuck in the allocator, so only a fresh process gets it back. Three times
-/// the healthy working point, and well under the 25 GB that prompted this work.
-const DEFAULT_RSS_HARD_MB: u64 = 16384;
+///
+/// It was 8192 while each daemon served one working directory. One daemon now
+/// serves all of them, so the same arithmetic is run for the three projects
+/// `RMC_MAX_PROJECTS` allows: 2.3 GB fixed + 3 × ~3 GB ≈ 11.3 GB. Note what the
+/// change is *not*: one daemon at 12 GB is less than the 12.5 GB that eleven of
+/// them held between them on the machine that prompted this, and unlike that
+/// fleet it is a number something actually enforces.
+const DEFAULT_RSS_SOFT_MB: u64 = 12288;
+/// Twenty gigabytes: past this, unloading has already been tried and the memory
+/// is stuck in the allocator, so only a fresh process gets it back. Kept at a
+/// ratio to the soft limit rather than at a fixed distance — the escalation
+/// wants room for a peak above the working point, not a constant.
+const DEFAULT_RSS_HARD_MB: u64 = 20480;
 /// Five minutes between unloads. Without a floor the watchdog would unload on
 /// every tick — RSS usually does *not* drop after an unload (see
 /// `rmc_server::mcp::memory`), so the trigger stays true and the next tick would
@@ -314,11 +358,31 @@ const DEFAULT_RSS_HARD_MB: u64 = 16384;
 /// guard into a performance disaster.
 const DEFAULT_RSS_COOLDOWN_SECS: u64 = 300;
 
+/// Six gigabytes of `MemAvailable`, and the number is set by what else is on the
+/// machine rather than by what the daemon costs.
+///
+/// The other three thresholds ask "is this process too big?", which a daemon can
+/// answer while the machine around it goes to swap — its own RSS is nobody's
+/// idea of the whole picture. This one asks "does the machine still have room?",
+/// and it is the only reading that sees pressure the daemon did not cause: a
+/// workspace build, a second analyser, the application under development.
+///
+/// Six is chosen to fire *before* the OOM machinery does. A typical `earlyoom`
+/// on a 61 GB desktop warns near 5 GB and starts killing near 2.4 GB; a floor
+/// below that would only ever unload after something had already been killed,
+/// which is not a guard. Higher than ~8 GB and an ordinary `cargo` build would
+/// evict the analysis every time, making every following query reload it.
+///
+/// `0` disables the check — including on any platform where `MemAvailable`
+/// cannot be read, since an unknown reading must not act like a violated floor.
+const DEFAULT_MIN_AVAILABLE_MB: u64 = 6144;
+
 impl WatchdogLimits {
     pub fn from_env() -> Self {
         Self {
             soft_mb: env_u64(RSS_SOFT_ENV, DEFAULT_RSS_SOFT_MB),
             hard_mb: env_u64(RSS_HARD_ENV, DEFAULT_RSS_HARD_MB),
+            min_available_mb: env_u64(MIN_AVAILABLE_ENV, DEFAULT_MIN_AVAILABLE_MB),
             cooldown: Duration::from_secs(env_u64(RSS_COOLDOWN_ENV, DEFAULT_RSS_COOLDOWN_SECS)),
         }
     }
@@ -380,8 +444,13 @@ fn env_u64(name: &str, default: u64) -> u64 {
 ///
 /// `since_unload` is `None` when nothing has been unloaded yet — the cooldown
 /// cannot bar the first attempt.
+///
+/// `available_mb` is `None` when the machine's free memory could not be read.
+/// That is treated as "the floor is not violated": an unreadable number must not
+/// act like an alarming one, or every non-Linux daemon would unload forever.
 pub fn decide_watchdog_action(
     rss_mb: u64,
+    available_mb: Option<u64>,
     limits: WatchdogLimits,
     since_unload: Option<Duration>,
     retiring: bool,
@@ -398,7 +467,19 @@ pub fn decide_watchdog_action(
         return WatchdogAction::Retire;
     }
 
-    if limits.soft_mb == 0 || rss_mb < limits.soft_mb {
+    let over_own_limit = limits.soft_mb > 0 && rss_mb >= limits.soft_mb;
+    // The machine's floor gets its own reason to unload rather than being folded
+    // into the soft limit: the pressure it reports is usually not ours, and a
+    // daemon at 3 GB next to a build that took the machine to swap is exactly
+    // the case the RSS thresholds cannot see.
+    //
+    // It stops at `Unload`, never `Retire`. Retiring unlinks the socket and puts
+    // a deadline on live sessions to answer memory pressure the daemon may not
+    // even have caused, and the pressure usually passes with the build.
+    let machine_is_short = limits.min_available_mb > 0
+        && available_mb.is_some_and(|available| available < limits.min_available_mb);
+
+    if !over_own_limit && !machine_is_short {
         return WatchdogAction::None;
     }
 
@@ -411,16 +492,52 @@ pub fn decide_watchdog_action(
 /// Where sockets live. `$XDG_RUNTIME_DIR` is preferred: it is private, on tmpfs,
 /// and cleaned out at logout together with any orphaned sockets.
 fn socket_dir() -> Result<PathBuf, BoxError> {
-    if let Ok(dir) = std::env::var(DAEMON_DIR_ENV) {
-        return Ok(PathBuf::from(dir));
+    let probed = probe_runtime_dir();
+    Ok(resolve_socket_dir(
+        std::env::var(DAEMON_DIR_ENV).ok().as_deref(),
+        std::env::var("XDG_RUNTIME_DIR").ok().as_deref(),
+        probed.as_deref(),
+        std::env::var("USER").ok().as_deref(),
+        &std::env::temp_dir(),
+    ))
+}
+
+/// `/run/user/<uid>`, if it exists — the directory `XDG_RUNTIME_DIR` would name.
+///
+/// Read from the filesystem rather than assumed: the uid comes from
+/// `/proc/self`, and the directory has to be there. A session started outside a
+/// login shell (a hook, a cron job, an editor spawned from a display manager)
+/// often has no `XDG_RUNTIME_DIR` at all, and without this it would compute the
+/// same key as its neighbours but look for it in `/tmp` — not find the running
+/// daemon, and start a second one. Both halves of that split were live on this
+/// machine at once, on two keys.
+fn probe_runtime_dir() -> Option<PathBuf> {
+    let uid = fs::metadata("/proc/self").ok()?.uid();
+    let dir = PathBuf::from(format!("/run/user/{uid}"));
+    dir.is_dir().then_some(dir)
+}
+
+/// The pure part of [`socket_dir`], for the same reason as [`key_from_parts`]:
+/// deciding this from tests otherwise means mutating global env in parallel
+/// with other tests.
+fn resolve_socket_dir(
+    env_dir: Option<&str>,
+    xdg: Option<&str>,
+    probed_runtime: Option<&Path>,
+    user: Option<&str>,
+    temp_dir: &Path,
+) -> PathBuf {
+    if let Some(dir) = env_dir.filter(|d| !d.is_empty()) {
+        return PathBuf::from(dir);
     }
-    if let Ok(runtime_dir) = std::env::var("XDG_RUNTIME_DIR") {
-        if !runtime_dir.is_empty() {
-            return Ok(PathBuf::from(runtime_dir).join("rust-code-mcp"));
-        }
+    if let Some(runtime_dir) = xdg.filter(|d| !d.is_empty()) {
+        return PathBuf::from(runtime_dir).join("rust-code-mcp");
     }
-    let user = std::env::var("USER").unwrap_or_else(|_| "shared".to_string());
-    Ok(std::env::temp_dir().join(format!("rust-code-mcp-{user}")))
+    if let Some(runtime_dir) = probed_runtime {
+        return runtime_dir.join("rust-code-mcp");
+    }
+    let user = user.filter(|u| !u.is_empty()).unwrap_or("shared");
+    temp_dir.join(format!("rust-code-mcp-{user}"))
 }
 
 fn ensure_dir(dir: &Path) -> io::Result<()> {
@@ -429,16 +546,17 @@ fn ensure_dir(dir: &Path) -> io::Result<()> {
     fs::set_permissions(dir, fs::Permissions::from_mode(0o700))
 }
 
-/// The daemon key: the project plus everything that changes what answers mean.
+/// The daemon key: everything that changes what an answer means.
 ///
 /// The binary contributes its size and mtime rather than a content hash: a
 /// rebuild must produce a *new* daemon (otherwise a client built from new code
 /// would be served by the old server), and reading tens of megabytes on every
 /// startup to establish that is not worth it.
-fn workspace_key() -> Result<String, BoxError> {
-    let cwd = std::env::current_dir()?;
-    let cwd = fs::canonicalize(&cwd).unwrap_or(cwd);
-
+///
+/// The working directory is deliberately absent — see the module docs. Adding
+/// anything here splits the fleet, so a new part earns its place only by
+/// changing what the server *computes*.
+fn daemon_key() -> Result<String, BoxError> {
     let exe = std::env::current_exe()?;
     let exe_meta = fs::metadata(&exe).ok();
     let exe_len = exe_meta.as_ref().map(|m| m.len()).unwrap_or(0);
@@ -459,7 +577,7 @@ fn workspace_key() -> Result<String, BoxError> {
         })
         .collect();
 
-    Ok(key_from_parts(&cwd, &exe, exe_len, exe_mtime, &env))
+    Ok(key_from_parts(&exe, exe_len, exe_mtime, &env))
 }
 
 /// The pure part of the key: everything that matters arrives as an argument.
@@ -467,16 +585,8 @@ fn workspace_key() -> Result<String, BoxError> {
 /// Split out of [`workspace_key`] for testability rather than tidiness: checking
 /// "the key changes with configuration" through `set_var` means mutating global
 /// env in parallel with other tests, which fails for reasons unrelated to keys.
-fn key_from_parts(
-    cwd: &Path,
-    exe: &Path,
-    exe_len: u64,
-    exe_mtime: u128,
-    env: &[(&str, String)],
-) -> String {
+fn key_from_parts(exe: &Path, exe_len: u64, exe_mtime: u128, env: &[(&str, String)]) -> String {
     let mut hasher = Sha256::new();
-    hasher.update(cwd.as_os_str().as_encoded_bytes());
-    hasher.update([0]);
     hasher.update(exe.as_os_str().as_encoded_bytes());
     hasher.update(exe_len.to_le_bytes());
     hasher.update(exe_mtime.to_le_bytes());
@@ -492,7 +602,7 @@ fn key_from_parts(
 }
 
 pub fn default_socket_path() -> Result<PathBuf, BoxError> {
-    Ok(socket_dir()?.join(format!("{}.sock", workspace_key()?)))
+    Ok(socket_dir()?.join(format!("{}.sock", daemon_key()?)))
 }
 
 fn lock_path(socket: &Path) -> PathBuf {
@@ -640,7 +750,13 @@ fn spawn_daemon(socket: &Path) -> io::Result<Child> {
         .stderr(Stdio::from(log))
         // Its own process group, so Ctrl-C in one client's session does not take
         // down a server other sessions are using.
-        .process_group(0);
+        .process_group(0)
+        // The root, not the spawning session's directory. One daemon serves
+        // every working directory, so inheriting one client's cwd would make it
+        // the accidental base for any relative path that slipped past the
+        // absolute-path gate — answering about the wrong tree instead of
+        // failing. `/` holds no Cargo project, so such a path fails loudly.
+        .current_dir("/");
     cmd.spawn()
 }
 
@@ -809,16 +925,24 @@ pub async fn run_daemon(
         }
 
         // Memory watchdog. Runs on the same tick as the idle check, so it costs
-        // one `/proc/self/status` read every 15 s and nothing else.
+        // one `/proc/self/status` and one `/proc/meminfo` read every 15 s and
+        // nothing else.
         if let Some(rss_mb) = rss_kib().map(|kib| kib / 1024) {
+            let available_mb = mem_available_kib().map(|kib| kib / 1024);
             let since_unload = last_unload.and_then(|at| at.elapsed().ok());
-            match decide_watchdog_action(rss_mb, limits, since_unload, retiring) {
+            match decide_watchdog_action(rss_mb, available_mb, limits, since_unload, retiring) {
                 WatchdogAction::None => {}
                 WatchdogAction::Unload => {
+                    // Which of the two reasons fired is worth naming: "RSS 3 GB,
+                    // unloading" would read as a bug in the threshold rather
+                    // than as the machine-wide floor doing its job.
                     tracing::warn!(
-                        "RSS {} MB is over the {} MB soft limit; unloading analysis contexts",
+                        "unloading analysis contexts: RSS {} MB (soft limit {} MB), \
+                         machine has {:?} MB available (floor {} MB)",
                         rss_mb,
-                        limits.soft_mb
+                        limits.soft_mb,
+                        available_mb,
+                        limits.min_available_mb
                     );
                     let report = runtime
                         .state()
@@ -927,13 +1051,17 @@ mod watchdog_tests {
     const LIMITS: WatchdogLimits = WatchdogLimits {
         soft_mb: 4096,
         hard_mb: 10240,
+        min_available_mb: 6144,
         cooldown: Duration::from_secs(300),
     };
+
+    /// A machine with room to spare, so a case about RSS is only about RSS.
+    const ROOMY: Option<u64> = Some(40_000);
 
     #[test]
     fn ordinary_memory_use_is_left_alone() {
         assert_eq!(
-            decide_watchdog_action(3000, LIMITS, None, false),
+            decide_watchdog_action(3000, ROOMY, LIMITS, None, false),
             WatchdogAction::None
         );
     }
@@ -941,7 +1069,7 @@ mod watchdog_tests {
     #[test]
     fn crossing_the_soft_limit_unloads() {
         assert_eq!(
-            decide_watchdog_action(5000, LIMITS, None, false),
+            decide_watchdog_action(5000, ROOMY, LIMITS, None, false),
             WatchdogAction::Unload
         );
     }
@@ -952,11 +1080,11 @@ mod watchdog_tests {
     #[test]
     fn a_second_unload_waits_for_the_cooldown() {
         assert_eq!(
-            decide_watchdog_action(5000, LIMITS, Some(Duration::from_secs(60)), false),
+            decide_watchdog_action(5000, ROOMY, LIMITS, Some(Duration::from_secs(60)), false),
             WatchdogAction::None
         );
         assert_eq!(
-            decide_watchdog_action(5000, LIMITS, Some(Duration::from_secs(600)), false),
+            decide_watchdog_action(5000, ROOMY, LIMITS, Some(Duration::from_secs(600)), false),
             WatchdogAction::Unload
         );
     }
@@ -966,7 +1094,7 @@ mod watchdog_tests {
     #[test]
     fn the_hard_limit_outranks_the_cooldown() {
         assert_eq!(
-            decide_watchdog_action(11000, LIMITS, Some(Duration::from_secs(1)), false),
+            decide_watchdog_action(11000, ROOMY, LIMITS, Some(Duration::from_secs(1)), false),
             WatchdogAction::Retire
         );
     }
@@ -976,7 +1104,7 @@ mod watchdog_tests {
     #[test]
     fn a_retiring_daemon_decides_nothing_further() {
         assert_eq!(
-            decide_watchdog_action(11000, LIMITS, None, true),
+            decide_watchdog_action(11000, ROOMY, LIMITS, None, true),
             WatchdogAction::None
         );
     }
@@ -988,7 +1116,7 @@ mod watchdog_tests {
             ..LIMITS
         };
         assert_eq!(
-            decide_watchdog_action(9000, no_soft, None, false),
+            decide_watchdog_action(9000, ROOMY, no_soft, None, false),
             WatchdogAction::None,
             "soft_mb = 0 must not unload"
         );
@@ -998,7 +1126,7 @@ mod watchdog_tests {
             ..LIMITS
         };
         assert_eq!(
-            decide_watchdog_action(99000, no_hard, None, false),
+            decide_watchdog_action(99000, ROOMY, no_hard, None, false),
             WatchdogAction::Unload,
             "hard_mb = 0 must never retire, however high RSS goes"
         );
@@ -1009,8 +1137,75 @@ mod watchdog_tests {
             ..LIMITS
         };
         assert_eq!(
-            decide_watchdog_action(99000, disabled, None, false),
+            decide_watchdog_action(99000, ROOMY, disabled, None, false),
             WatchdogAction::None
+        );
+    }
+
+    /// The case none of the RSS thresholds can see: this daemon is small, and
+    /// the machine is in trouble anyway — a build, a second analyser, the
+    /// application under development. The caches belong to whoever needs the
+    /// memory more.
+    #[test]
+    fn a_short_machine_unloads_even_a_small_daemon() {
+        assert_eq!(
+            decide_watchdog_action(3000, Some(2000), LIMITS, None, false),
+            WatchdogAction::Unload,
+            "3 GB of RSS is fine; 2 GB left on the machine is not"
+        );
+    }
+
+    /// It unloads and stops there. Retiring unlinks the socket and puts a
+    /// deadline on live sessions — too much for pressure that is usually
+    /// somebody else's and passes with the build that caused it.
+    #[test]
+    fn a_short_machine_never_retires() {
+        assert_eq!(
+            decide_watchdog_action(3000, Some(0), LIMITS, None, false),
+            WatchdogAction::Unload,
+            "even at zero available memory the floor may not retire the daemon"
+        );
+    }
+
+    /// The floor is rate-limited like the soft limit, and for the same reason:
+    /// the memory usually does not come back to the machine on the next tick.
+    #[test]
+    fn the_floor_respects_the_cooldown() {
+        assert_eq!(
+            decide_watchdog_action(3000, Some(2000), LIMITS, Some(Duration::from_secs(60)), false),
+            WatchdogAction::None
+        );
+    }
+
+    #[test]
+    fn a_roomy_machine_and_a_small_daemon_are_left_alone() {
+        assert_eq!(
+            decide_watchdog_action(3000, Some(6144), LIMITS, None, false),
+            WatchdogAction::None,
+            "exactly at the floor is not below it"
+        );
+    }
+
+    /// Two ways for the floor to be silent, and both must be: `0` is the opt-out,
+    /// and `None` is "the reading could not be taken". An unknown number that
+    /// acted like an alarming one would unload forever on any platform without
+    /// `/proc`.
+    #[test]
+    fn an_unknown_or_disabled_floor_never_fires() {
+        assert_eq!(
+            decide_watchdog_action(3000, None, LIMITS, None, false),
+            WatchdogAction::None,
+            "unreadable available memory must not read as pressure"
+        );
+
+        let no_floor = WatchdogLimits {
+            min_available_mb: 0,
+            ..LIMITS
+        };
+        assert_eq!(
+            decide_watchdog_action(3000, Some(1), no_floor, None, false),
+            WatchdogAction::None,
+            "min_available_mb = 0 disables the check"
         );
     }
 
@@ -1029,11 +1224,12 @@ mod watchdog_tests {
         let defaults = WatchdogLimits {
             soft_mb: DEFAULT_RSS_SOFT_MB,
             hard_mb: DEFAULT_RSS_HARD_MB,
+            min_available_mb: DEFAULT_MIN_AVAILABLE_MB,
             cooldown: Duration::from_secs(DEFAULT_RSS_COOLDOWN_SECS),
         };
 
         assert_eq!(
-            decide_watchdog_action(MEASURED_HEALTHY_MB, defaults, None, false),
+            decide_watchdog_action(MEASURED_HEALTHY_MB, ROOMY, defaults, None, false),
             WatchdogAction::None,
             "a daemon at the measured healthy working point ({MEASURED_HEALTHY_MB} MB) must be \
              left alone; soft limit is {DEFAULT_RSS_SOFT_MB} MB"
@@ -1044,16 +1240,31 @@ mod watchdog_tests {
         );
     }
 
+    /// The machine-wide floor has to sit above where an OOM killer starts
+    /// choosing victims, or it only ever fires after something has been killed —
+    /// which is not a guard. `earlyoom -m 8,4` on a 61 GB desktop kills near
+    /// 2.4 GB; a floor at or below that would be decoration.
+    #[test]
+    fn the_machine_floor_leaves_room_before_the_oom_killer() {
+        const TYPICAL_OOM_KILL_MB: u64 = 2440;
+
+        assert!(
+            DEFAULT_MIN_AVAILABLE_MB > TYPICAL_OOM_KILL_MB,
+            "a floor at {DEFAULT_MIN_AVAILABLE_MB} MB must leave room above the \
+             ~{TYPICAL_OOM_KILL_MB} MB where the OOM killer starts"
+        );
+    }
+
     /// Exactly at the limit counts as over it — a threshold that only fires
     /// strictly above leaves a value that reads as tripped but does nothing.
     #[test]
     fn thresholds_are_inclusive() {
         assert_eq!(
-            decide_watchdog_action(4096, LIMITS, None, false),
+            decide_watchdog_action(4096, ROOMY, LIMITS, None, false),
             WatchdogAction::Unload
         );
         assert_eq!(
-            decide_watchdog_action(10240, LIMITS, None, false),
+            decide_watchdog_action(10240, ROOMY, LIMITS, None, false),
             WatchdogAction::Retire
         );
     }
@@ -1197,9 +1408,8 @@ mod tests {
         assert!(resolve_mode(&owned).is_err());
     }
 
-    fn key(cwd: &str, exe: &str, len: u64, mtime: u128, sync: &str) -> String {
+    fn key(exe: &str, len: u64, mtime: u128, sync: &str) -> String {
         key_from_parts(
-            Path::new(cwd),
             Path::new(exe),
             len,
             mtime,
@@ -1209,29 +1419,114 @@ mod tests {
 
     #[test]
     fn key_is_stable_for_same_inputs() {
-        assert_eq!(
-            key("/repo", "/bin/mcp", 10, 20, "1"),
-            key("/repo", "/bin/mcp", 10, 20, "1")
-        );
+        assert_eq!(key("/bin/mcp", 10, 20, "1"), key("/bin/mcp", 10, 20, "1"));
     }
 
     /// Configuration must split daemons: a server started with different
     /// behaviour-changing env does not answer what the new client is asking for.
     #[test]
     fn key_depends_on_keyed_env() {
-        assert_ne!(
-            key("/repo", "/bin/mcp", 10, 20, "1"),
-            key("/repo", "/bin/mcp", 10, 20, "0")
+        assert_ne!(key("/bin/mcp", 10, 20, "1"), key("/bin/mcp", 10, 20, "0"));
+    }
+
+    /// The inverse of the old `key_depends_on_project`, and the whole point of
+    /// this change: sessions started in different directories must land on ONE
+    /// daemon. Keying on the cwd bought no isolation — every tool takes its
+    /// `directory` as a parameter — and cost 11 processes holding 12.5 GB.
+    ///
+    /// Judged on the real `daemon_key()`, not on `key_from_parts`: the pure
+    /// helper no longer takes a cwd at all, so asking it would prove nothing.
+    /// The process-wide cwd is restored, and no other test in this binary reads
+    /// it.
+    #[test]
+    fn key_does_not_depend_on_the_working_directory() {
+        let original = std::env::current_dir().expect("a working directory");
+
+        std::env::set_current_dir("/tmp").expect("chdir /tmp");
+        let from_tmp = daemon_key().expect("a key");
+
+        std::env::set_current_dir("/").expect("chdir /");
+        let from_root = daemon_key().expect("a key");
+
+        std::env::set_current_dir(&original).expect("chdir back");
+
+        assert_eq!(
+            from_tmp, from_root,
+            "one daemon serves every working directory"
         );
     }
 
-    /// Different projects, different daemons — otherwise "one per project" turns
-    /// into "one for everything".
     #[test]
-    fn key_depends_on_project() {
-        assert_ne!(
-            key("/repo-a", "/bin/mcp", 10, 20, "1"),
-            key("/repo-b", "/bin/mcp", 10, 20, "1")
+    fn an_explicit_directory_wins() {
+        assert_eq!(
+            resolve_socket_dir(
+                Some("/explicit"),
+                Some("/run/user/1000"),
+                Some(Path::new("/run/user/1000")),
+                Some("sc"),
+                Path::new("/tmp")
+            ),
+            PathBuf::from("/explicit")
+        );
+    }
+
+    #[test]
+    fn the_runtime_dir_is_preferred_when_the_environment_names_it() {
+        assert_eq!(
+            resolve_socket_dir(
+                None,
+                Some("/run/user/1000"),
+                None,
+                Some("sc"),
+                Path::new("/tmp")
+            ),
+            PathBuf::from("/run/user/1000/rust-code-mcp")
+        );
+    }
+
+    /// The split this closes. A session started outside a login shell has no
+    /// `XDG_RUNTIME_DIR`, computes the same key as its neighbours, and used to
+    /// look for the socket in `/tmp` — where it found nothing and started a
+    /// second daemon. Both halves of that were live on this machine at once, on
+    /// two separate keys.
+    #[test]
+    fn a_missing_xdg_variable_still_finds_the_runtime_directory() {
+        assert_eq!(
+            resolve_socket_dir(
+                None,
+                None,
+                Some(Path::new("/run/user/1000")),
+                Some("sc"),
+                Path::new("/tmp")
+            ),
+            PathBuf::from("/run/user/1000/rust-code-mcp"),
+            "an unset XDG_RUNTIME_DIR must not send this client to a different directory \
+             than its neighbours"
+        );
+        assert_eq!(
+            resolve_socket_dir(
+                Some(""),
+                Some(""),
+                Some(Path::new("/run/user/1000")),
+                Some("sc"),
+                Path::new("/tmp")
+            ),
+            PathBuf::from("/run/user/1000/rust-code-mcp"),
+            "empty is as unset as unset"
+        );
+    }
+
+    /// With no runtime directory at all — a container, a non-systemd host — the
+    /// old per-user temp directory is still the answer.
+    #[test]
+    fn without_a_runtime_directory_it_falls_back_to_temp() {
+        assert_eq!(
+            resolve_socket_dir(None, None, None, Some("sc"), Path::new("/tmp")),
+            PathBuf::from("/tmp/rust-code-mcp-sc")
+        );
+        assert_eq!(
+            resolve_socket_dir(None, None, None, None, Path::new("/tmp")),
+            PathBuf::from("/tmp/rust-code-mcp-shared")
         );
     }
 
@@ -1240,13 +1535,13 @@ mod tests {
     #[test]
     fn key_depends_on_binary_identity() {
         assert_ne!(
-            key("/repo", "/bin/mcp", 10, 20, "1"),
-            key("/repo", "/bin/mcp", 10, 21, "1"),
+            key("/bin/mcp", 10, 20, "1"),
+            key("/bin/mcp", 10, 21, "1"),
             "a different binary mtime means a different daemon"
         );
         assert_ne!(
-            key("/repo", "/bin/mcp", 10, 20, "1"),
-            key("/repo", "/bin/mcp", 11, 20, "1"),
+            key("/bin/mcp", 10, 20, "1"),
+            key("/bin/mcp", 11, 20, "1"),
             "a different binary size means a different daemon"
         );
     }

--- a/crates/rust-code-mcp/src/daemon.rs
+++ b/crates/rust-code-mcp/src/daemon.rs
@@ -74,6 +74,9 @@ pub const RSS_SOFT_ENV: &str = "RMC_RSS_SOFT_MB";
 pub const RSS_HARD_ENV: &str = "RMC_RSS_HARD_MB";
 /// Minimum gap between two unloads, in seconds — see [`WatchdogAction`].
 pub const RSS_COOLDOWN_ENV: &str = "RMC_RSS_COOLDOWN_SECS";
+/// How long a retired daemon waits for its clients to leave before exiting
+/// anyway, in seconds. `0` means wait forever — see [`retire_grace_expired`].
+pub const RETIRE_GRACE_ENV: &str = "RMC_RETIRE_GRACE_SECS";
 
 /// Env vars that change what the server computes, and therefore which daemon a
 /// client belongs to. Extend this list whenever a new behaviour-changing knob is
@@ -230,7 +233,49 @@ pub enum WatchdogAction {
     /// hand every attached session the `Connection closed` error that this
     /// whole mechanism exists to prevent — a self-inflicted version of the
     /// failure we are trying to avoid.
+    ///
+    /// The waiting is bounded, and it has to be — see [`retire_grace_expired`].
     Retire,
+}
+
+/// Thirty minutes, deliberately the same number as [`DEFAULT_IDLE_SECS`].
+///
+/// The policy it states is easy to hold in the head: *no daemon outlives the
+/// idle timeout once it has been retired*, whatever its clients are doing. An
+/// idle daemon already exits after half an hour of silence; a retired one is
+/// strictly worse than idle — it is over the hard memory limit, its socket is
+/// gone, and every new client goes to a successor — so it has no business
+/// living longer than that.
+const DEFAULT_RETIRE_GRACE_SECS: u64 = 1800;
+
+/// Has a retired daemon waited long enough that it should exit even though
+/// clients are still attached?
+///
+/// # Why the wait needs an end at all
+///
+/// [`WatchdogAction::Retire`] hands the socket to a successor and then waits for
+/// `live == 0`. That wait is unbounded, and its length is decided by something
+/// the daemon does not control: how long a client session lasts. A Claude Code
+/// session runs for hours, so the mechanism meant to *free* memory produced its
+/// opposite — measured 2026-08-27, a retired daemon sat on **24.2 GB** next to a
+/// live successor, and the two together were what exhausted this machine's swap.
+///
+/// # The price, stated plainly
+///
+/// Exiting on the deadline breaks the connections still attached. The proxy is
+/// byte-level and remembers no handshake, so a client whose daemon vanishes does
+/// not silently reattach to the successor — that session loses its MCP tools
+/// until it restarts them. That is the trade this knob makes: one session's
+/// tools against gigabytes held away from the whole machine. It only ever
+/// applies past the hard RSS limit, which is why the deadline can be generous.
+///
+/// `grace` of zero disables the deadline and restores the original
+/// wait-forever behaviour.
+pub fn retire_grace_expired(retiring_for: Option<Duration>, grace: Duration) -> bool {
+    if grace.is_zero() {
+        return false;
+    }
+    retiring_for.is_some_and(|elapsed| elapsed >= grace)
 }
 
 /// Thresholds for [`decide_watchdog_action`], in MB. `0` disables a threshold.
@@ -274,6 +319,15 @@ impl WatchdogLimits {
             cooldown: Duration::from_secs(env_u64(RSS_COOLDOWN_ENV, DEFAULT_RSS_COOLDOWN_SECS)),
         }
     }
+}
+
+/// The retire deadline, read from the environment.
+///
+/// Kept out of [`WatchdogLimits`] on purpose: those three numbers are the inputs
+/// of [`decide_watchdog_action`], and this one is not — it governs what happens
+/// *after* that decision has already been made.
+fn retire_grace_from_env() -> Duration {
+    Duration::from_secs(env_u64(RETIRE_GRACE_ENV, DEFAULT_RETIRE_GRACE_SECS))
 }
 
 fn env_u64(name: &str, default: u64) -> u64 {
@@ -500,13 +554,42 @@ pub async fn run_client(socket: &Path) -> Result<bool, BoxError> {
     }
 }
 
+/// Size at which a daemon log is rolled aside on the next spawn. Generous on
+/// purpose: an indexing run writes hundreds of kilobytes in minutes, and a log
+/// that rolls mid-investigation is barely better than one that is truncated.
+const LOG_ROTATE_BYTES: u64 = 32 * 1024 * 1024;
+
+/// Roll the current log aside if it has grown past [`LOG_ROTATE_BYTES`].
+///
+/// Exactly one generation is kept (`<key>.log.1`). Failures are deliberately
+/// ignored: losing the previous log is not a reason to fail to start a daemon.
+fn rotate_log_if_large(path: &Path) {
+    let too_big = fs::metadata(path).is_ok_and(|meta| meta.len() >= LOG_ROTATE_BYTES);
+    if too_big {
+        let _ = fs::rename(path, path.with_extension("log.1"));
+    }
+}
+
+/// Open the log a spawned daemon writes its stderr into.
+///
+/// Append, never truncate. A successor is spawned precisely when its
+/// predecessor is in trouble — over the hard memory limit, or dead — and
+/// truncating here destroyed that predecessor's log at the exact moment someone
+/// was about to read it. Measured 2026-08-27: a retired daemon holding 24.2 GB
+/// whose entire history had been overwritten by the successor that replaced it,
+/// so *why* it grew could not be reconstructed at all.
+///
+/// Daemons are told apart inside the shared file by the pid on their
+/// `daemon listening on …` line.
+fn open_daemon_log(socket: &Path) -> io::Result<File> {
+    let path = log_path(socket);
+    rotate_log_if_large(&path);
+    OpenOptions::new().create(true).append(true).open(path)
+}
+
 fn spawn_daemon(socket: &Path) -> io::Result<Child> {
     let exe = std::env::current_exe()?;
-    let log = OpenOptions::new()
-        .create(true)
-        .write(true)
-        .truncate(true)
-        .open(log_path(socket))?;
+    let log = open_daemon_log(socket)?;
 
     let mut cmd = Command::new(exe);
     cmd.arg("--daemon")
@@ -600,9 +683,12 @@ pub async fn run_daemon(
             socket.display()
         ))
     })?;
+    // The pid is what makes a shared, appended log readable: successive daemons
+    // write into the same file, and this line is the boundary between them.
     tracing::info!(
-        "daemon listening on {} (idle timeout {:?})",
+        "daemon listening on {} (pid {}, idle timeout {:?})",
         socket.display(),
+        std::process::id(),
         idle
     );
 
@@ -619,10 +705,18 @@ pub async fn run_daemon(
         RSS_HARD_ENV,
         RSS_COOLDOWN_ENV,
     );
+    let retire_grace = retire_grace_from_env();
+    tracing::info!(
+        "retire deadline: a retired daemon exits after {:?} even with clients attached ({} to change; 0 waits forever)",
+        retire_grace,
+        RETIRE_GRACE_ENV,
+    );
     let mut last_unload: Option<SystemTime> = None;
     // Once retiring, the socket file is gone and belongs to whoever binds it
     // next — this flag keeps the exit path from deleting a successor's socket.
+    // `retiring_since` is what bounds the wait; see `retire_grace_expired`.
     let mut retiring = false;
+    let mut retiring_since: Option<SystemTime> = None;
 
     // Signals must reach the same exit path as an idle timeout. A daemon killed
     // outright leaves its socket file behind; clients survive that (they clear it
@@ -712,12 +806,31 @@ pub async fn run_daemon(
                     // while the connections already open keep working.
                     let _ = fs::remove_file(socket);
                     retiring = true;
+                    retiring_since = Some(SystemTime::now());
                 }
             }
         }
 
         if retiring && live.load(Ordering::SeqCst) == 0 {
             tracing::info!("last client left after retiring; shutting down");
+            break;
+        }
+
+        // The deadline. Without it this daemon waits for clients that outlive
+        // it by hours, holding whatever pushed it past the hard limit in the
+        // first place.
+        if retiring
+            && retire_grace_expired(
+                retiring_since.and_then(|at| at.elapsed().ok()),
+                retire_grace,
+            )
+        {
+            tracing::warn!(
+                "retired {:?} ago and {} client(s) are still attached; exiting anyway on the {} deadline — those connections will drop",
+                retire_grace,
+                live.load(Ordering::SeqCst),
+                RETIRE_GRACE_ENV,
+            );
             break;
         }
 
@@ -885,6 +998,60 @@ mod watchdog_tests {
             WatchdogAction::Retire
         );
     }
+
+    const GRACE: Duration = Duration::from_secs(1800);
+
+    /// A daemon that has not retired has no deadline to expire, however long it
+    /// has been running.
+    #[test]
+    fn a_daemon_that_never_retired_has_no_deadline() {
+        assert!(!retire_grace_expired(None, GRACE));
+    }
+
+    /// The waiting period is real: a daemon that retired a moment ago must give
+    /// its clients their chance to finish, not drop them on the same tick.
+    #[test]
+    fn a_freshly_retired_daemon_keeps_waiting() {
+        assert!(!retire_grace_expired(Some(Duration::from_secs(60)), GRACE));
+        assert!(!retire_grace_expired(
+            Some(GRACE - Duration::from_secs(1)),
+            GRACE
+        ));
+    }
+
+    /// And it ends. This is the whole point of the knob: on 2026-08-27 a retired
+    /// daemon held 24.2 GB waiting for a session that ran for hours.
+    #[test]
+    fn the_deadline_eventually_fires() {
+        assert!(retire_grace_expired(Some(GRACE), GRACE));
+        assert!(retire_grace_expired(Some(Duration::from_secs(7200)), GRACE));
+    }
+
+    /// Zero restores the original behaviour — wait for the last client, however
+    /// long that takes. Without this the knob could not be turned off, and a
+    /// daemon on a machine with memory to spare would drop sessions for nothing.
+    #[test]
+    fn zero_grace_waits_forever() {
+        let forever = Duration::ZERO;
+        assert!(!retire_grace_expired(
+            Some(Duration::from_secs(86400)),
+            forever
+        ));
+        assert!(!retire_grace_expired(None, forever));
+    }
+
+    /// The deadline is only useful strictly *inside* the idle timeout: a retired
+    /// daemon is worse than an idle one, so it must not be allowed to outlive
+    /// one. Equal is the deliberate choice — this guards against someone raising
+    /// the default past it.
+    #[test]
+    fn the_default_deadline_does_not_exceed_the_idle_timeout() {
+        assert!(
+            DEFAULT_RETIRE_GRACE_SECS <= DEFAULT_IDLE_SECS,
+            "a retired daemon outliving the idle timeout defeats the deadline: an idle daemon \
+             would already have exited by then"
+        );
+    }
 }
 
 #[cfg(test)]
@@ -982,6 +1149,77 @@ mod tests {
             key("/repo", "/bin/mcp", 10, 20, "1"),
             key("/repo", "/bin/mcp", 11, 20, "1"),
             "a different binary size means a different daemon"
+        );
+    }
+
+    /// The regression this exists for: a successor must not erase the log of the
+    /// daemon it is replacing. That log is the only account of *why* the
+    /// predecessor grew, and it was being destroyed at the one moment it
+    /// mattered.
+    #[test]
+    fn a_successor_appends_to_the_log_instead_of_erasing_it() {
+        use std::io::Write as _;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let socket = dir.path().join("key.sock");
+        let predecessor = "predecessor: RSS 24000 MB is over the hard limit\n";
+        std::fs::write(log_path(&socket), predecessor).expect("seed the predecessor's log");
+
+        let mut log = open_daemon_log(&socket).expect("successor opens the log");
+        write!(log, "successor: daemon listening (pid 2)\n").expect("successor writes");
+
+        let contents = std::fs::read_to_string(log_path(&socket)).expect("read back");
+        assert!(
+            contents.starts_with(predecessor),
+            "the predecessor's log must survive its successor's start, got {contents:?}"
+        );
+        assert!(
+            contents.contains("successor:"),
+            "the successor's own lines must be there too, got {contents:?}"
+        );
+    }
+
+    /// Appending forever is its own failure mode, so one generation is kept.
+    /// Sparse allocation keeps this test from writing 32 MB to disk.
+    #[test]
+    fn an_oversized_log_is_rolled_aside_rather_than_grown() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let socket = dir.path().join("key.sock");
+        let log = log_path(&socket);
+
+        let file = File::create(&log).expect("create the oversized log");
+        file.set_len(LOG_ROTATE_BYTES).expect("grow it sparsely");
+        drop(file);
+
+        open_daemon_log(&socket).expect("open after rotation");
+
+        assert_eq!(
+            std::fs::metadata(&log).map(|meta| meta.len()).unwrap_or(0),
+            0,
+            "the fresh log must start empty once the old one was rolled aside"
+        );
+        assert_eq!(
+            std::fs::metadata(log.with_extension("log.1"))
+                .expect("the rolled-aside generation must exist")
+                .len(),
+            LOG_ROTATE_BYTES,
+            "the previous generation must be kept intact, not discarded"
+        );
+    }
+
+    /// A log under the limit is left exactly where it is — rotating on every
+    /// spawn would reintroduce the very loss this pair of tests guards.
+    #[test]
+    fn a_small_log_is_not_rotated() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let socket = dir.path().join("key.sock");
+        std::fs::write(log_path(&socket), "small\n").expect("seed");
+
+        open_daemon_log(&socket).expect("open");
+
+        assert!(
+            !log_path(&socket).with_extension("log.1").exists(),
+            "nothing should have been rolled aside"
         );
     }
 }

--- a/crates/rust-code-mcp/src/main.rs
+++ b/crates/rust-code-mcp/src/main.rs
@@ -4,6 +4,11 @@
 // compile-time inference budget, not a runtime cost.
 #![recursion_limit = "512"]
 
+// One server per project instead of one per session; see `daemon`. Unix only —
+// the transport is a unix socket, other platforms keep the stdio server.
+#[cfg(unix)]
+mod daemon;
+
 use rmc_server::mcp::{
     cuda_capable_features_compiled, install_automatic_backend, parse_background_sync_env,
     resolve_automatic_profile_name, validate_automatic_profile, ServerRuntime,
@@ -31,6 +36,49 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_writer(std::io::stderr)
         .with_ansi(false)
         .init();
+
+    // Resolve the mode before the expensive startup: a client of the shared
+    // daemon needs neither a `ServerRuntime` nor a background sync task — it is
+    // a pipe between stdio and the socket.
+    #[cfg(unix)]
+    let mode = {
+        let args: Vec<String> = std::env::args().skip(1).collect();
+        match daemon::resolve_mode(&args) {
+            Ok(mode) => mode,
+            Err(e) => {
+                eprintln!("{e}\n\n{}", daemon::USAGE);
+                // Explicit coercion site: `main` returns `Box<dyn Error>` without
+                // `Send + Sync`, and without the typed let inference takes the
+                // whole body with it.
+                let boxed: Box<dyn std::error::Error> = e;
+                return Err(boxed);
+            }
+        }
+    };
+
+    #[cfg(unix)]
+    match &mode {
+        daemon::Mode::Help => {
+            print!("{}", daemon::USAGE);
+            return Ok(());
+        }
+        daemon::Mode::PrintSocket { socket } => {
+            println!("{}", socket.display());
+            return Ok(());
+        }
+        daemon::Mode::Client { socket } => {
+            // A failing daemon never leaves the session without a server: fall
+            // through to the previous in-process behaviour.
+            match daemon::run_client(socket).await {
+                Ok(true) => return Ok(()),
+                Ok(false) => {
+                    tracing::info!("shared daemon unavailable; serving this session in-process")
+                }
+                Err(e) => tracing::warn!("shared daemon client failed: {e}; serving in-process"),
+            }
+        }
+        daemon::Mode::Daemon { .. } | daemon::Mode::InProcess => {}
+    }
 
     tracing::info!("Starting MCP Server...");
 
@@ -76,6 +124,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             "Background sync task disabled; set {}=1 to enable",
             BACKGROUND_SYNC_ENV
         );
+    }
+
+    // Daemon: the same runtime, but many connections instead of one stdio pipe.
+    #[cfg(unix)]
+    if let daemon::Mode::Daemon { socket, idle } = &mode {
+        let result = daemon::run_daemon(socket, *idle, &runtime).await;
+        let shutdown = runtime.shutdown_gracefully(Duration::from_secs(10)).await;
+        tracing::info!("Runtime shutdown after daemon exit: {:?}", shutdown);
+        return result.map_err(|e| -> Box<dyn std::error::Error> { e });
     }
 
     let service = match SearchTool::with_server_runtime(&runtime).serve(stdio()).await {

--- a/crates/rust-code-mcp/src/main.rs
+++ b/crates/rust-code-mcp/src/main.rs
@@ -9,6 +9,15 @@
 #[cfg(unix)]
 mod daemon;
 
+// Under the `mimalloc` feature every allocation in the process — including
+// rust-analyzer's salsa database, which is what actually fills the heap — goes
+// through mimalloc instead of the system allocator. The reason is in the
+// feature's comment in Cargo.toml; the short version is that glibc keeps its
+// fragmented arenas and mimalloc gives them back.
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL_ALLOCATOR: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 use rmc_server::mcp::{
     cuda_capable_features_compiled, install_automatic_backend, parse_background_sync_env,
     resolve_automatic_profile_name, validate_automatic_profile, ServerRuntime,

--- a/crates/rust-code-mcp/tests/test_burn_performance.rs
+++ b/crates/rust-code-mcp/tests/test_burn_performance.rs
@@ -17,7 +17,7 @@ use anyhow::Result;
 use std::time::Instant;
 
 async fn index_burn_codebase(force: bool) -> Result<(String, std::time::Duration)> {
-    use rmc_server::tools::{index_codebase, IndexCodebaseParams};
+    use rmc_server::tools::{IndexCodebaseParams, index_codebase};
 
     let params = IndexCodebaseParams {
         directory: "/home/molaco/Documents/burn".to_string(),
@@ -27,7 +27,10 @@ async fn index_burn_codebase(force: bool) -> Result<(String, std::time::Duration
     };
 
     let start = Instant::now();
-    let result = index_codebase(params, None)
+    // Workspace lock registry: this perf test runs one pass at a time, but the
+    // function takes it as a required argument.
+    let locks = rmc_server::mcp::WorkspaceLockRegistry::new();
+    let result = index_codebase(params, None, &locks, None)
         .await
         .map_err(|e| anyhow::anyhow!("MCP error: {:?}", e))?;
     let elapsed = start.elapsed();
@@ -84,11 +87,15 @@ async fn test_burn_gpu_performance() -> Result<()> {
     let total_chunks = result.match_indices("Total chunks:").count();
 
     println!("Performance Metrics:");
-    println!("  Total time: {:.2} minutes ({:.2}s)",
+    println!(
+        "  Total time: {:.2} minutes ({:.2}s)",
         elapsed.as_secs_f64() / 60.0,
         elapsed.as_secs_f64()
     );
-    println!("  Files/sec: {:.2}", file_count as f64 / elapsed.as_secs_f64());
+    println!(
+        "  Files/sec: {:.2}",
+        file_count as f64 / elapsed.as_secs_f64()
+    );
 
     if result.contains("chunks") {
         println!("\n✓ Successfully indexed Burn codebase");
@@ -110,13 +117,19 @@ async fn test_burn_gpu_performance() -> Result<()> {
     println!("========================================");
     println!("Files indexed: {}", file_count);
     println!("Time: {:.2} minutes", elapsed.as_secs_f64() / 60.0);
-    println!("Throughput: {:.1} files/sec", file_count as f64 / elapsed.as_secs_f64());
+    println!(
+        "Throughput: {:.1} files/sec",
+        file_count as f64 / elapsed.as_secs_f64()
+    );
     println!();
     println!("Comparison with CPU baseline (10 minutes):");
     let cpu_baseline = 600.0; // 10 minutes in seconds
     let speedup = cpu_baseline / elapsed.as_secs_f64();
     println!("  Speedup: {:.2}x faster", speedup);
-    println!("  Time saved: {:.1} minutes", (cpu_baseline - elapsed.as_secs_f64()) / 60.0);
+    println!(
+        "  Time saved: {:.1} minutes",
+        (cpu_baseline - elapsed.as_secs_f64()) / 60.0
+    );
     println!("========================================\n");
 
     Ok(())
@@ -144,9 +157,15 @@ async fn test_burn_incremental_index() -> Result<()> {
     println!("========================================");
     println!("Incremental Indexing Results");
     println!("========================================");
-    println!("Full index:        {:.2} minutes", elapsed1.as_secs_f64() / 60.0);
+    println!(
+        "Full index:        {:.2} minutes",
+        elapsed1.as_secs_f64() / 60.0
+    );
     println!("Incremental index: {:.2} seconds", elapsed2.as_secs_f64());
-    println!("Speedup:           {:.0}x faster", elapsed1.as_secs_f64() / elapsed2.as_secs_f64());
+    println!(
+        "Speedup:           {:.0}x faster",
+        elapsed1.as_secs_f64() / elapsed2.as_secs_f64()
+    );
     println!("========================================\n");
 
     Ok(())

--- a/crates/rust-code-mcp/tests/test_daemon_shared_runtime.rs
+++ b/crates/rust-code-mcp/tests/test_daemon_shared_runtime.rs
@@ -36,7 +36,17 @@ impl Session {
     /// `socket_dir` is per test: otherwise a run would attach to the daemon of a
     /// live working session and assert about someone else's process.
     fn start(socket_dir: &Path, shared: bool) -> Result<Self> {
+        Self::start_in(socket_dir, shared, None)
+    }
+
+    /// As [`Session::start`], with the client's working directory chosen by the
+    /// caller — the axis `two_clients_from_different_directories_share_one_process`
+    /// is about.
+    fn start_in(socket_dir: &Path, shared: bool, cwd: Option<&Path>) -> Result<Self> {
         let mut command = Command::new(env!("CARGO_BIN_EXE_rust-code-mcp"));
+        if let Some(cwd) = cwd {
+            command.current_dir(cwd);
+        }
         command
             .env("RUST_LOG", "error")
             .env("RMC_DAEMON_DIR", socket_dir)
@@ -197,6 +207,49 @@ fn two_clients_share_one_server_process() -> Result<()> {
         "the call was served by the client itself, so no daemon came up and nothing is shared"
     );
     assert_ne!(second_pid, second.child.id());
+
+    drop(first);
+    drop(second);
+    kill_pid(first_pid);
+    Ok(())
+}
+
+/// The same oracle along the axis that used to split the fleet: two sessions
+/// started in DIFFERENT directories must still be served by one process.
+///
+/// The daemon key included the working directory until this test existed. It
+/// bought no isolation — every tool takes its `directory` as a parameter, so the
+/// cwd never chose the project — and it cost, measured on one machine, eleven
+/// processes holding 12.5 GB, several of them analysing the same repository.
+///
+/// Mutation that must fail it: put the cwd back into `key_from_parts`, and the
+/// two pids diverge.
+#[test]
+fn two_clients_from_different_directories_share_one_process() -> Result<()> {
+    let socket_dir = TempDir::new()?;
+    let first_cwd = TempDir::new()?;
+    let second_cwd = TempDir::new()?;
+
+    let mut first = Session::start_in(socket_dir.path(), true, Some(first_cwd.path()))?;
+    let first_pid = first.serving_pid()?;
+    let mut second = Session::start_in(socket_dir.path(), true, Some(second_cwd.path()))?;
+    let second_pid = second.serving_pid()?;
+
+    assert_eq!(
+        first_pid, second_pid,
+        "sessions started in {} and {} were served by different processes — the daemon key is \
+         splitting on the working directory again",
+        first_cwd.path().display(),
+        second_cwd.path().display()
+    );
+    // Same positive control as the sibling test: without it, "one pid" would not
+    // rule out both calls having been served in-process by two clients that
+    // happen to be compared wrongly.
+    assert_ne!(
+        first_pid,
+        first.child.id(),
+        "the call was served by the client itself, so no daemon came up and nothing is shared"
+    );
 
     drop(first);
     drop(second);

--- a/crates/rust-code-mcp/tests/test_daemon_shared_runtime.rs
+++ b/crates/rust-code-mcp/tests/test_daemon_shared_runtime.rs
@@ -1,0 +1,251 @@
+//! The oracle for the shared daemon: however many sessions attach to a project,
+//! the analysis lives in ONE process.
+//!
+//! What is checked is not "a daemon came up" but the sharing itself:
+//! `runtime_status` reports the pid of the process that actually served the call.
+//! Two clients, one pid — the state is shared; two different pids — every session
+//! is loading its own copy of the rust-analyzer context again, which is precisely
+//! the regression the daemon exists to prevent.
+//!
+//! The positive control sits right next to it: with `RMC_DAEMON=0` the pid must
+//! equal the client's own. Without it the first test would only prove that two
+//! calls returned the same number, without distinguishing that from "both were
+//! served somewhere else entirely".
+
+#![cfg(unix)]
+
+use anyhow::{Context, Result, anyhow};
+use serde_json::{Value, json};
+use std::io::{BufRead, BufReader, Write};
+use std::path::Path;
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
+use std::thread;
+use std::time::{Duration, Instant};
+use tempfile::TempDir;
+
+/// An MCP client: the binary plus a pipe to it.
+struct Session {
+    child: Child,
+    stdin: ChildStdin,
+    rx: Receiver<std::io::Result<String>>,
+    next_id: u64,
+}
+
+impl Session {
+    /// `socket_dir` is per test: otherwise a run would attach to the daemon of a
+    /// live working session and assert about someone else's process.
+    fn start(socket_dir: &Path, shared: bool) -> Result<Self> {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_rust-code-mcp"));
+        command
+            .env("RUST_LOG", "error")
+            .env("RMC_DAEMON_DIR", socket_dir)
+            // The daemon must not outlive the run: the idle tick is 15s, so an
+            // orphan exits on its own even if the test fails before the kill.
+            .env("RMC_DAEMON_IDLE_SECS", "5")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null());
+        if shared {
+            command.env_remove("RMC_DAEMON");
+        } else {
+            command.env("RMC_DAEMON", "0");
+        }
+
+        let mut child = command.spawn().context("failed to spawn the MCP client")?;
+        let stdout = child.stdout.take().context("child stdout was not piped")?;
+        let stdin = child.stdin.take().context("child stdin was not piped")?;
+
+        let (tx, rx) = mpsc::channel();
+        thread::spawn(move || {
+            for line in BufReader::new(stdout).lines() {
+                if tx.send(line).is_err() {
+                    break;
+                }
+            }
+        });
+
+        let mut session = Self {
+            child,
+            stdin,
+            rx,
+            next_id: 1,
+        };
+        session.handshake()?;
+        Ok(session)
+    }
+
+    fn handshake(&mut self) -> Result<()> {
+        let id = self.request(
+            "initialize",
+            json!({
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": { "name": "daemon-sharing-test", "version": "0.0.0" }
+            }),
+        )?;
+        let response = self.read_response(id, Duration::from_secs(120))?;
+        if response.get("error").is_some() {
+            return Err(anyhow!("initialize failed: {response}"));
+        }
+        self.notify("notifications/initialized", json!({}))
+    }
+
+    fn request(&mut self, method: &str, params: Value) -> Result<u64> {
+        let id = self.next_id;
+        self.next_id += 1;
+        self.send(json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": params }))?;
+        Ok(id)
+    }
+
+    fn notify(&mut self, method: &str, params: Value) -> Result<()> {
+        self.send(json!({ "jsonrpc": "2.0", "method": method, "params": params }))
+    }
+
+    fn send(&mut self, message: Value) -> Result<()> {
+        serde_json::to_writer(&mut self.stdin, &message)?;
+        self.stdin.write_all(b"\n")?;
+        self.stdin.flush()?;
+        Ok(())
+    }
+
+    fn read_response(&self, id: u64, timeout: Duration) -> Result<Value> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return Err(anyhow!("timed out waiting for response id {id}"));
+            }
+            let line = match self.rx.recv_timeout(remaining) {
+                Ok(line) => line?,
+                Err(RecvTimeoutError::Timeout) => {
+                    return Err(anyhow!("timed out waiting for response id {id}"));
+                }
+                Err(RecvTimeoutError::Disconnected) => {
+                    return Err(anyhow!("server closed stdout before response id {id}"));
+                }
+            };
+            let value: Value = serde_json::from_str(&line)
+                .with_context(|| format!("stdout contained a non-JSON-RPC line: {line:?}"))?;
+            if value.get("id").and_then(Value::as_u64) == Some(id) {
+                return Ok(value);
+            }
+        }
+    }
+
+    /// The pid of the process that ACTUALLY serves this session's calls.
+    fn serving_pid(&mut self) -> Result<u32> {
+        let id = self.request(
+            "tools/call",
+            json!({ "name": "runtime_status", "arguments": {} }),
+        )?;
+        let response = self.read_response(id, Duration::from_secs(120))?;
+        if response.get("error").is_some() {
+            return Err(anyhow!("runtime_status failed: {response}"));
+        }
+        let text = response
+            .pointer("/result/content/0/text")
+            .and_then(Value::as_str)
+            .ok_or_else(|| anyhow!("no status text in the response: {response}"))?;
+        let status: Value = serde_json::from_str(text)?;
+        status
+            .pointer("/process/pid")
+            .and_then(Value::as_u64)
+            .map(|pid| pid as u32)
+            .ok_or_else(|| anyhow!("no process.pid in the status: {text}"))
+    }
+}
+
+impl Drop for Session {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn kill_pid(pid: u32) {
+    let _ = Command::new("kill").arg(pid.to_string()).status();
+}
+
+fn wait_until(timeout: Duration, mut done: impl FnMut() -> bool) -> Option<()> {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if done() {
+            return Some(());
+        }
+        thread::sleep(Duration::from_millis(20));
+    }
+    None
+}
+
+#[test]
+fn two_clients_share_one_server_process() -> Result<()> {
+    let socket_dir = TempDir::new()?;
+
+    let mut first = Session::start(socket_dir.path(), true)?;
+    let first_pid = first.serving_pid()?;
+    let mut second = Session::start(socket_dir.path(), true)?;
+    let second_pid = second.serving_pid()?;
+
+    assert_eq!(
+        first_pid, second_pid,
+        "two sessions were served by different processes, so each holds its own copy of the analysis"
+    );
+    assert_ne!(
+        first_pid,
+        first.child.id(),
+        "the call was served by the client itself, so no daemon came up and nothing is shared"
+    );
+    assert_ne!(second_pid, second.child.id());
+
+    drop(first);
+    drop(second);
+    kill_pid(first_pid);
+    Ok(())
+}
+
+/// A killed daemon must remove its own socket file.
+///
+/// Clients survive a stale socket — they clear it and start a new daemon. But
+/// while the file is there, `--print-socket` plus `ls` point at an address where
+/// nobody listens, so diagnostics lie exactly when someone comes to read them.
+#[test]
+fn killed_daemon_removes_its_socket() -> Result<()> {
+    let dir = TempDir::new()?;
+    let socket = dir.path().join("probe.sock");
+
+    let mut daemon = Command::new(env!("CARGO_BIN_EXE_rust-code-mcp"))
+        .arg("--daemon")
+        .arg("--socket")
+        .arg(&socket)
+        .env("RUST_LOG", "error")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+
+    wait_until(Duration::from_secs(60), || socket.exists())
+        .ok_or_else(|| anyhow!("the daemon never bound its socket"))?;
+
+    kill_pid(daemon.id());
+    let gone = wait_until(Duration::from_secs(30), || !socket.exists());
+    let _ = daemon.wait();
+    gone.ok_or_else(|| anyhow!("SIGTERM left a stale {}", socket.display()))?;
+    Ok(())
+}
+
+/// Positive control: the opt-out must restore the previous behaviour.
+#[test]
+fn opt_out_serves_in_process() -> Result<()> {
+    let socket_dir = TempDir::new()?;
+
+    let mut session = Session::start(socket_dir.path(), false)?;
+    let serving_pid = session.serving_pid()?;
+
+    assert_eq!(
+        serving_pid,
+        session.child.id(),
+        "with RMC_DAEMON=0 the client process itself must serve the session"
+    );
+    Ok(())
+}

--- a/crates/rust-code-mcp/tests/test_index_tool_integration.rs
+++ b/crates/rust-code-mcp/tests/test_index_tool_integration.rs
@@ -8,11 +8,32 @@
 //! 5. Result formatting
 
 use anyhow::Result;
-use rmc_server::mcp::SyncManager;
-use rmc_server::tools::{index_codebase, IndexCodebaseParams};
+use rmc_server::mcp::{SyncManager, WorkspaceLockRegistry};
+use rmc_server::tools::{IndexCodebaseParams, index_codebase};
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::OnceLock;
 use tempfile::TempDir;
+
+/// The lock registry these tests hand to `index_codebase`.
+///
+/// Neither the registry nor the search cache is the subject of these tests, but
+/// the function requires both. The registry is ONE per test binary, as it is on
+/// a live server where it lives with the process: a fresh one per call would
+/// silently drop the serialisation of identical workspaces, so the tests would
+/// exercise a path production never takes. The search cache is `None` — nothing
+/// here observes it.
+fn workspace_locks() -> &'static WorkspaceLockRegistry {
+    static LOCKS: OnceLock<WorkspaceLockRegistry> = OnceLock::new();
+    LOCKS.get_or_init(WorkspaceLockRegistry::new)
+}
+
+async fn index(
+    params: IndexCodebaseParams,
+    sync_manager: Option<&Arc<SyncManager>>,
+) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
+    index_codebase(params, sync_manager, workspace_locks(), None).await
+}
 
 struct IndexToolTestEnv {
     _temp_dir: TempDir,
@@ -63,7 +84,7 @@ async fn test_index_tool_invalid_directory() {
         embedding_profile: None,
     };
 
-    let result = index_codebase(params, None).await;
+    let result = index(params, None).await;
 
     assert!(result.is_err(), "Should return error for nonexistent path");
     println!("✓ Invalid directory rejected correctly");
@@ -82,7 +103,7 @@ async fn test_index_tool_not_a_directory() -> Result<()> {
         embedding_profile: None,
     };
 
-    let result = index_codebase(params, None).await;
+    let result = index(params, None).await;
 
     assert!(result.is_err(), "Should return error for file path");
     println!("✓ File path rejected correctly");
@@ -96,17 +117,23 @@ async fn test_index_tool_basic_indexing() -> Result<()> {
     let env = IndexToolTestEnv::new()?;
 
     // Create test files
-    env.write_file("main.rs", r#"
+    env.write_file(
+        "main.rs",
+        r#"
         fn main() {
             println!("Hello, world!");
         }
-    "#)?;
+    "#,
+    )?;
 
-    env.write_file("lib.rs", r#"
+    env.write_file(
+        "lib.rs",
+        r#"
         pub fn library_function() -> i32 {
             42
         }
-    "#)?;
+    "#,
+    )?;
 
     let params = IndexCodebaseParams {
         directory: env.get_path_string(),
@@ -115,12 +142,15 @@ async fn test_index_tool_basic_indexing() -> Result<()> {
         embedding_profile: None,
     };
 
-    let result = index_codebase(params, None).await;
+    let result = index(params, None).await;
 
     assert!(result.is_ok(), "Should successfully index valid codebase");
     let call_result = result.unwrap();
     assert!(call_result.is_error.is_none() || !call_result.is_error.unwrap());
-    assert!(!call_result.content.is_empty(), "Should have result content");
+    assert!(
+        !call_result.content.is_empty(),
+        "Should have result content"
+    );
 
     println!("✓ Basic indexing works");
 
@@ -141,7 +171,7 @@ async fn test_index_tool_empty_directory() -> Result<()> {
         embedding_profile: None,
     };
 
-    let result = index_codebase(params, None).await;
+    let result = index(params, None).await;
 
     assert!(result.is_ok(), "Should handle empty directory gracefully");
 
@@ -158,11 +188,11 @@ async fn test_index_tool_no_changes_detection() -> Result<()> {
     env.write_file("test.rs", "fn test() {}")?;
 
     // First index
-    let result1 = index_codebase(env.create_params(false), None).await;
+    let result1 = index(env.create_params(false), None).await;
     assert!(result1.is_ok());
 
     // Second index - should detect no changes
-    let result2 = index_codebase(env.create_params(false), None).await;
+    let result2 = index(env.create_params(false), None).await;
     assert!(result2.is_ok());
 
     println!("✓ No changes detection works");
@@ -178,11 +208,11 @@ async fn test_index_tool_force_reindex() -> Result<()> {
     env.write_file("test.rs", "fn test() {}")?;
 
     // First index
-    let result1 = index_codebase(env.create_params(false), None).await;
+    let result1 = index(env.create_params(false), None).await;
     assert!(result1.is_ok());
 
     // Force reindex - should reindex everything
-    let result2 = index_codebase(env.create_params(true), None).await;
+    let result2 = index(env.create_params(true), None).await;
     assert!(result2.is_ok());
 
     println!("✓ Force reindex works");
@@ -211,12 +241,16 @@ async fn test_index_tool_with_sync_manager() -> Result<()> {
     };
 
     // Index with sync manager
-    let result = index_codebase(params, Some(&sync_manager)).await;
+    let result = index(params, Some(&sync_manager)).await;
     assert!(result.is_ok());
 
     // Directory should now be tracked
     let tracked = sync_manager.get_tracked_directories().await;
-    assert_eq!(tracked.len(), 1, "Directory should be added to sync manager");
+    assert_eq!(
+        tracked.len(),
+        1,
+        "Directory should be added to sync manager"
+    );
     assert!(tracked.contains(&env.codebase_path));
 
     println!("✓ Integration with SyncManager works");
@@ -236,7 +270,7 @@ async fn test_index_tool_nested_structure() -> Result<()> {
     env.write_file("src/utils/helper.rs", "pub fn help() {}")?;
     env.write_file("tests/integration_test.rs", "#[test] fn test() {}")?;
 
-    let result = index_codebase(env.create_params(false), None).await;
+    let result = index(env.create_params(false), None).await;
 
     assert!(result.is_ok(), "Should handle nested structure");
 
@@ -255,14 +289,14 @@ async fn test_index_tool_incremental_update() -> Result<()> {
     env.write_file("file2.rs", "fn file2() {}")?;
 
     // First index
-    let result1 = index_codebase(env.create_params(false), None).await;
+    let result1 = index(env.create_params(false), None).await;
     assert!(result1.is_ok());
 
     // Add new file
     env.write_file("file3.rs", "fn file3() {}")?;
 
     // Second index - should detect new file
-    let result2 = index_codebase(env.create_params(false), None).await;
+    let result2 = index(env.create_params(false), None).await;
     assert!(result2.is_ok());
 
     println!("✓ Incremental update detected");
@@ -275,15 +309,18 @@ async fn test_index_tool_incremental_update() -> Result<()> {
 async fn test_index_tool_result_format() -> Result<()> {
     let env = IndexToolTestEnv::new()?;
 
-    env.write_file("test.rs", r#"
+    env.write_file(
+        "test.rs",
+        r#"
         /// Test function
         pub fn test_function() -> i32 {
             println!("Testing");
             42
         }
-    "#)?;
+    "#,
+    )?;
 
-    let result = index_codebase(env.create_params(false), None).await?;
+    let result = index(env.create_params(false), None).await?;
 
     // Verify result structure
     assert!(!result.content.is_empty(), "Should have content");
@@ -304,7 +341,7 @@ async fn test_index_tool_with_non_rust_files() -> Result<()> {
     env.write_file("config.toml", "[package]")?;
     env.write_file(".gitignore", "target/")?;
 
-    let result = index_codebase(env.create_params(false), None).await;
+    let result = index(env.create_params(false), None).await;
 
     assert!(result.is_ok(), "Should handle mixed file types");
 
@@ -322,13 +359,13 @@ async fn test_index_tool_performance() -> Result<()> {
     for i in 0..20 {
         env.write_file(
             &format!("file{}.rs", i),
-            &format!("pub fn function_{}() {{ println!(\"test\"); }}", i)
+            &format!("pub fn function_{}() {{ println!(\"test\"); }}", i),
         )?;
     }
 
     // First index
     let start1 = std::time::Instant::now();
-    let result1 = index_codebase(env.create_params(false), None).await;
+    let result1 = index(env.create_params(false), None).await;
     let elapsed1 = start1.elapsed();
     assert!(result1.is_ok());
 
@@ -336,12 +373,15 @@ async fn test_index_tool_performance() -> Result<()> {
 
     // Second index (no changes) - should be much faster
     let start2 = std::time::Instant::now();
-    let result2 = index_codebase(env.create_params(false), None).await;
+    let result2 = index(env.create_params(false), None).await;
     let elapsed2 = start2.elapsed();
     assert!(result2.is_ok());
 
     println!("Second index (no changes): {:?}", elapsed2);
-    println!("Speedup: {:.1}x", elapsed1.as_secs_f64() / elapsed2.as_secs_f64());
+    println!(
+        "Speedup: {:.1}x",
+        elapsed1.as_secs_f64() / elapsed2.as_secs_f64()
+    );
 
     assert!(elapsed2 < elapsed1, "Second index should be faster");
 

--- a/crates/rust-code-mcp/tests/test_mcp_stdio_transport.rs
+++ b/crates/rust-code-mcp/tests/test_mcp_stdio_transport.rs
@@ -82,6 +82,10 @@ fn test_index_codebase_force_reindex_stdout_is_json_only() -> Result<()> {
     let mut child = ChildGuard {
         child: Command::new(env!("CARGO_BIN_EXE_rust-code-mcp"))
             .env("RUST_LOG", "error")
+            // This test is about the in-process stdio path. Without the opt-out
+            // it would run through the shared daemon and leave it holding an
+            // index of the temporary directory this test then deletes.
+            .env("RMC_DAEMON", "0")
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::null())


### PR DESCRIPTION
## The problem

The stdio transport is 1:1 with its client by construction: one pipe, one process. Every editor window or agent session therefore spawns its own `rust-code-mcp`, and with it another `SemanticService` — the loaded rust-analyzer context for the workspace, around 2 GB — plus another ONNX/GPU context.

Measured on one developer machine before this change: **six live servers, 8.9 GB, all analyzing the same repository.**

## Why this is a transport change and not a refactor

The runtime state is already shareable and already partitioned by project:

- `RuntimeState` is a bundle of `Arc`s (`Arc<Mutex<SemanticService>>`, the search cache, the flags);
- `SemanticService` caches contexts in a `HashMap<PathBuf, ProjectContext>`;
- locking is per workspace (`WorkspaceLockRegistry`), not global — so two projects never block each other, while two sessions on the same project serialize, which is what you want.

The only missing piece was a transport that accepts more than one client. This PR adds it, and then hardens what a server that outlives its sessions turns out to need.

## What it does

- The binary **with no arguments** is now a *client* of the daemon, and starts that daemon on first use — **no `.mcp.json` change is required.**
- The daemon serves every connection with its own `SearchToolRouter` over one shared `RuntimeState`, and exits after 30 minutes with no clients (`--idle-secs`, `RMC_DAEMON_IDLE_SECS`, `0` = never).
- **A failing daemon never leaves a client without a server.** Any failure along connect / spawn / wait falls back to the previous in-process path, so this is a memory optimisation rather than a new point of failure. `RMC_DAEMON=0` opts out entirely.
- Unix only (`#[cfg(unix)]`); other platforms keep the stdio server unchanged.

```bash
rust-code-mcp --print-socket   # which socket this configuration resolves to
rust-code-mcp --in-process     # previous behaviour (same as RMC_DAEMON=0)
rust-code-mcp --daemon         # run the daemon in the foreground
```

## The commits, in the order they were found

The first commit is the transport. Everything after it is a consequence that only appears once a server outlives the session that started it, and each was found by running the thing rather than by reading it:

| | |
|---|---|
| `rust-code-mcp test targets compile again` | pre-existing on `main` and unrelated, but `--all-targets` is red without it, so nothing below can be judged |
| `one server per project via a unix-socket daemon` | the transport |
| `one walker for "which .rs files belong to a project"` | the indexer's walk, lifted so the staleness check below can ask the same question |
| `watch memory, refresh stale contexts, report RSS honestly` | a cached context must notice edits made while it idled; and dropping one returns **zero** bytes to the kernel |
| `set the watchdog thresholds from a measurement, not a guess` | the first default sat *below* a healthy daemon and would have unloaded on every cooldown |
| `give a retired daemon a deadline instead of waiting forever` | a retired daemon sat on 24.2 GB next to its successor |
| `run rust-analyzer work on a stack that fits it` | a 2 MiB tokio stack `abort`s the whole server, not one call |
| `hold the working set down instead of waiting for an operator` | a project cap and a GC timer — measured 14.6 GB, mostly directories nobody had touched for hours |
| `reject relative path parameters` | the prerequisite for the next one |
| `one daemon per user, and a reading of the machine's memory` | see below |
| `announce the machine-memory floor like the other four knobs` | a knob the server does not name is a knob nobody knows about |
| `let a retired daemon unload instead of sitting on gigabytes` | one early `return` silenced the whole policy, not one decision |
| `keep a private workspace path out of the examples` | tidying |
| `make the graph round-trip test check membership, not hash order` | it asked for the default page of 50 out of ~90 bindings returned in node-id (hash) order, so any edit in rmc-graph could reshuffle the page and fail it |
| `stop retiring a healthy daemon, and unload a retired one at once` | the hard limit sat *inside* the working range of one `Full` context, so retirement fired three times in two hours with nothing wrong — and the retired daemon then waited out a cooldown before dropping anything |
| `stop letting a failed write pass for an up-to-date index` | an ENOSPC in the middle of an indexing run, and the Merkle snapshot still said the index was current |
| `document the raised hard limit and the index disk guard` | a knob whose documented default is the old one is worse than an undocumented knob |

Rebased onto `main` after [f40be52](https://github.com/molaco/rust-code-mcp/commit/f40be5265bd5c62b73f4b609a01545f9d2a0ccfb) landed; `RMC_EMBEDDING_PROFILE` is part of the socket key because of it.

## Three decisions worth reviewing

**The socket key is the configuration, not the directory.** It covers the binary's size and mtime and the env vars that change what the server computes (`KEYED_ENV` in `daemon.rs`, currently `RMC_EMBEDDING_PROFILE` and `RMC_BACKGROUND_SYNC`; **it must grow whenever a new behaviour-changing knob is added**). It deliberately does *not* cover the working directory — it used to, and the result was one daemon per directory a session happened to start in: 11 processes holding 12.5 GB between them, several analysing the same repository. cwd never selected the project in the first place, since every tool takes its `directory` as a parameter.

**The consequence is that path parameters must now be absolute.** The daemon shares no working directory with the session asking, so a relative path would answer about the wrong tree instead of refusing. `require_absolute` is wired into 11 call sites, of which `open_workspace_snapshot` covers six dozen tools at once. This is the one behaviour change a caller can notice.

**Signals exit through the same path as the idle timeout**, so a killed daemon removes its own socket. Clients survive a stale socket — they clear it and start a new daemon — but while the file is there, `--print-socket` plus `ls` point at an address where nobody listens, which is diagnostics lying exactly when someone comes to read them.

## Keeping a long-lived daemon bounded

Six knobs, all in seconds or MB, all with `0` meaning *off*:

| Knob | Default | What it does |
|---|---:|---|
| `RMC_MAX_PROJECTS` | 3 | How many rust-analyzer contexts stay loaded; the least recently used is dropped, never the one being queried. |
| `RMC_GC_INTERVAL_SECS` | 300 | How often loaded analyses are garbage-collected. |
| `RMC_RSS_SOFT_MB` | 12288 | RSS above which all contexts are unloaded (at most one unload per `RMC_RSS_COOLDOWN_SECS`). |
| `RMC_MIN_AVAILABLE_MB` | 6144 | Machine-wide floor on `MemAvailable` — the only reading that sees pressure the daemon did not cause. Never retires, only unloads. |
| `RMC_RSS_HARD_MB` | 28672 | RSS above which unloading is judged hopeless: unlink the socket, unload the contexts on that same tick, let current clients finish. |
| `RMC_RETIRE_GRACE_SECS` | 1800 | How long a retired daemon waits for them before exiting anyway — **this drops those connections**, and is only ever reached past the hard threshold. |

The cooldown is not optional: RSS usually does *not* drop right after an unload, so the trigger stays true and without it the watchdog would unload on every tick. It does not apply to a retired daemon's *first* unload, though: retirement changes the economics rather than the nature of unloading — that daemon takes no new clients and its successor is already loading — so it must not inherit an unrelated countdown while sitting on 20+ GB.

The hard limit is a measurement and not a round number, and the measurement moved once. At 20480 it sat inside the 15–21 GB working range of a single `Full` rust-analyzer context, so a *healthy* daemon retired three times in two hours, each time putting a 30-minute deadline on live sessions' connections. Loading `Fast` instead would have been the cheaper fix and the wrong one: `Fast` loses cross-crate and `#[cfg(test)]` references, i.e. it buys memory with wrong answers. `defaults_do_not_retire_at_the_measured_full_context_peak` is the gate against walking that back.

## Index durability

The daemon also survives its sessions where writes are concerned, and one night made that visible: `No space left on device` in the middle of an indexing run, after which the Merkle snapshot was still written *in full* — so every later background tick compared the tree against it and concluded there was nothing to do. Two files were left as ghosts: a metadata-cache entry with no vectors behind it, which pins the health probe's coverage at `degraded` indefinitely.

| Knob | Default | What it does |
|---|---:|---|
| `RMC_MIN_INDEX_FREE_MB` | 2048 | Refuse persistent index writes below this much free space — checked before a run, before each file, and before every batch. `0` disables. |

Beyond the guard, the run now tells the truth about itself: `IndexStats` separates a deliberate skip from a retryable failure, the committed snapshot keeps the *previous* node for every path whose write failed (so the next comparison presents exactly those paths again — the retry falls out of the data structure rather than needing a queue), the snapshot itself is written to a temporary file and renamed instead of truncating the last good one, and `index_codebase` reports "⚠ Partially indexed" with the failure count where it used to report success.

## A note on our salsa and rust-analyzer forks

Everything in this PR builds against the **published** `ra_ap_*` crates — the only analysis API it needs is `AnalysisHost::trigger_garbage_collection`, which is upstream. But the other end of the memory story is not upstream, and it is worth saying out loud since it explains why the GC timer exists at all:

- we run a **fork of rust-analyzer** that brings back *runtime LRU capacities* per salsa query (and makes them address real queries rather than names that match nothing — they were silently being set on nothing), and teaches def maps, item trees, symbol indices and type inference to report how much heap they hold;
- and a **fork of salsa** exposing per-ingredient memory (`Database::memory_usage`, `lru_capacity_names`), which is what makes "who is holding the gigabytes" answerable instead of guessed.

None of that is in this PR — the tool that reports it (`analysis_memory`) and the capacity sweep are left out precisely because they do not compile against the published crates. Say the word if you want them: they can be published as forks with a `[patch]` section, or kept out of this repository entirely.

What this means for a reviewer: `RMC_GC_INTERVAL_SECS` is the half that lives *here*. salsa drops memos only inside `reset_for_new_revision`, i.e. on a revision bump, and a project loaded into a daemon and then left alone receives no edits and therefore no bumps — its LRU capacities, whatever they are, never evict anything. The timer is where the bumps come from. With the forks it evicts from capped queries; without them it still bumps revisions and still helps, it just has fewer queries to evict from.

## Measurements after the change

On a ~4k-file workspace: three clients served by **one 2.3 GB process**; second handshake **0.01 s** against 2.66 s for the first (which pays for the spawn and model init). One daemon at 12 GB against 12.5 GB across eleven — and unlike that sum, it is a number something checks.

## Tests

`crates/rust-code-mcp/tests/test_daemon_shared_runtime.rs`:

- two clients must report **one pid** from `runtime_status` — the pid of whoever actually served the call;
- two clients **started from different working directories** must also report one pid. Checked by mutation (put cwd back into the key): exactly this test and the unit test on the key fail, while the older same-directory test stays green — nothing covered that path before;
- **positive control**: with `RMC_DAEMON=0` that pid must equal the client's own. Without it the first test would only prove two calls returned the same number, without distinguishing that from "both were served somewhere else";
- a killed daemon must remove its socket file.

Plus unit tests in `daemon.rs` for mode parsing, the socket key, and the watchdog policy as a pure function — including `defaults_do_not_fire_on_a_healthy_daemon`, which is the gate against re-introducing a threshold that unloads a *healthy* daemon once per cooldown. The key was split into a pure `key_from_parts` for testability: asserting on it via `set_var` means mutating global env in parallel with other tests, which is how the first version of that test failed.

The existing stdio-framing test now sets `RMC_DAEMON=0`, since it is specifically about the in-process path.

On the `rmc-server` side: the staleness path (references that only appear after an edit, a call site added in a new file, an untouched project that must NOT reload), the project-cap eviction order and the protection of the project in use, and the garbage collection judged both by the revision bump and by the answers being unchanged afterwards.

For the index-durability commit, in `rmc-indexing`: `partial_snapshot_retries_failed_add_modify_and_delete` (a failed addition, modification and deletion in one run, all three presented as changed again afterwards), `snapshot_replacement_keeps_a_loadable_complete_file`, `disk_headroom_guard_is_inclusive_and_can_be_disabled`, `transient_file_errors_are_reported_for_retry`, and in `rmc-server` `format_result_does_not_call_a_retryable_partial_run_success`.

```
cargo check --workspace --all-targets
cargo test -p rust-code-mcp --bin rust-code-mcp --test test_daemon_shared_runtime
cargo test -p rmc-indexing -p rmc-server --lib
```

`--all-targets` is green with the first commit of this series; it was red on `main` before it, for a reason unrelated to any of this.

