### PR TITLE
fix(server): run rust-analyzer work on a stack that fits it

### DIFF
--- a/crates/rmc-server/src/deep_stack.rs
+++ b/crates/rmc-server/src/deep_stack.rs
@@ -1,0 +1,211 @@
+//! Running rust-analyzer work on a stack deep enough for it.
+//!
+//! Work that loads a workspace through rust-analyzer walks HIR/AST trees
+//! recursively — the graph tools building a hypergraph, the audits, the
+//! skeleton builder alike. That recursion is bounded by the *shape of the
+//! analyzed source*, not by anything we control, and it does not fit in the
+//! 2 MiB stack a tokio blocking-pool thread gets by default: building the
+//! hypergraph for this very workspace aborted the process with
+//!
+//! ```text
+//! thread 'tokio-rt-worker' has overflowed its stack
+//! fatal runtime error: stack overflow, aborting
+//! ```
+//!
+//! A stack overflow is an `abort`, not a `panic` — it takes the whole MCP
+//! server down rather than failing one tool call, so this is not something a
+//! caller can guard against, and on a server shared by several sessions it ends
+//! all of them at once. The work therefore carries its own stack instead of
+//! depending on whoever spawned it.
+
+use std::sync::{Arc, Mutex};
+
+use rmcp::ErrorData as McpError;
+
+use crate::semantic::SemanticService;
+
+/// Stack for the analysis thread.
+///
+/// Measured, not guessed: the default 2 MiB aborts on this workspace, 32 MiB
+/// completes it. 64 MiB doubles the headroom that measurement gives us, and
+/// costs only address space — thread stacks are mapped lazily, so the pages a
+/// shallower walk never touches are never backed by memory.
+const ANALYSIS_STACK_BYTES: usize = 64 * 1024 * 1024;
+
+/// Run blocking rust-analyzer work on a dedicated thread with a deep stack, and
+/// await its result.
+///
+/// Replaces `tokio::task::spawn_blocking` for this kind of work. The blocking
+/// pool is otherwise the right tool — the point of the swap is solely the stack
+/// size, which the pool does not let us set per task.
+pub(crate) async fn run_analysis<T, F>(what: &'static str, work: F) -> Result<T, McpError>
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
+{
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    std::thread::Builder::new()
+        .name("rmc-analysis".to_string())
+        .stack_size(ANALYSIS_STACK_BYTES)
+        .spawn(move || {
+            // A send error means the caller went away; nothing to report to.
+            let _ = tx.send(work());
+        })
+        .map_err(|error| {
+            McpError::internal_error(
+                format!("{what}: failed to spawn analysis thread: {error}"),
+                None,
+            )
+        })?;
+
+    // The sender is dropped without sending only if the thread panicked, which
+    // is the same failure `spawn_blocking` reported as a join error.
+    rx.await
+        .map_err(|_| McpError::internal_error(format!("{what}: analysis thread panicked"), None))
+}
+
+/// Run work against the shared [`SemanticService`] on the analysis thread.
+///
+/// Every semantic call loads or queries a rust-analyzer workspace, so every one
+/// of them belongs on [`run_analysis`]'s stack for the reason in this module's
+/// header. This is the single door to the service from an async context so that
+/// the choice is made once rather than at each call site: taking the mutex
+/// inline in an `async fn` gets the 2 MiB worker stack *and* blocks the runtime
+/// for the duration of the analysis, and both are easy to reintroduce by
+/// accident when the lock is one `.lock()` away.
+///
+/// The closure receives the locked service and reports its own failures, so a
+/// caller keeps its own error wording rather than inheriting one from here. A
+/// poisoned mutex is the only failure this adds.
+pub(crate) async fn with_semantic<T, F>(
+    semantic: &Arc<Mutex<SemanticService>>,
+    what: &'static str,
+    work: F,
+) -> Result<T, McpError>
+where
+    F: FnOnce(&mut SemanticService) -> Result<T, McpError> + Send + 'static,
+    T: Send + 'static,
+{
+    let semantic = Arc::clone(semantic);
+    run_analysis(what, move || {
+        let mut service = semantic.lock().map_err(|error| {
+            McpError::internal_error(format!("Failed to acquire lock: {}", error), None)
+        })?;
+        work(&mut service)
+    })
+    .await?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn a_result_travels_back_from_the_analysis_thread() {
+        let value = run_analysis("test", || 6 * 7)
+            .await
+            .expect("analysis result");
+        assert_eq!(value, 42);
+    }
+
+    #[tokio::test]
+    async fn recursion_that_overflows_a_default_thread_completes_here() {
+        // Positive control for the stack size itself rather than for the
+        // plumbing: this frame chain needs far more than the 2 MiB a tokio
+        // blocking thread would hand us, so the test fails by aborting if
+        // `stack_size` ever stops being applied.
+        fn burn(depth: usize, sink: &mut u64) -> u64 {
+            // A big live frame, kept from being optimized away by feeding it
+            // into the running sum.
+            let block = [0xABu8; 8192];
+            *sink = sink.wrapping_add(block[depth % block.len()] as u64);
+            if depth == 0 {
+                *sink
+            } else {
+                burn(depth - 1, sink)
+            }
+        }
+
+        let mut sink = 0;
+        // ~1000 frames × 8 KiB ≈ 8 MiB of live frames.
+        let total = run_analysis("test", move || burn(1000, &mut sink))
+            .await
+            .expect("deep recursion completes");
+        assert!(total > 0, "the recursion must actually have run");
+    }
+
+    fn test_semantic() -> Arc<Mutex<SemanticService>> {
+        Arc::new(Mutex::new(SemanticService::new()))
+    }
+
+    #[tokio::test]
+    async fn semantic_work_leaves_the_runtime_worker() {
+        // The regression this guards is a call site taking the mutex inline in
+        // an `async fn`: that runs rust-analyzer on the worker's 2 MiB stack,
+        // which is what aborted the whole server. The thread name is how that
+        // choice becomes observable from the closure.
+        let semantic = test_semantic();
+        let thread_name = with_semantic(&semantic, "test", |_| {
+            Ok(std::thread::current().name().map(str::to_string))
+        })
+        .await
+        .expect("semantic work runs");
+        assert_eq!(thread_name.as_deref(), Some("rmc-analysis"));
+    }
+
+    #[tokio::test]
+    async fn semantic_work_gets_the_deep_stack_too() {
+        // Positive control end to end: the same frame chain that a worker
+        // thread cannot hold must complete through the semantic door.
+        fn burn(depth: usize, sink: &mut u64) -> u64 {
+            let block = [0xCDu8; 8192];
+            *sink = sink.wrapping_add(block[depth % block.len()] as u64);
+            if depth == 0 {
+                *sink
+            } else {
+                burn(depth - 1, sink)
+            }
+        }
+
+        let semantic = test_semantic();
+        let total = with_semantic(&semantic, "test", |_| {
+            let mut sink = 0;
+            Ok(burn(1000, &mut sink))
+        })
+        .await
+        .expect("deep recursion completes");
+        assert!(total > 0, "the recursion must actually have run");
+    }
+
+    #[tokio::test]
+    async fn a_poisoned_semantic_mutex_is_reported_rather_than_panicking() {
+        let semantic = test_semantic();
+        let poisoner = Arc::clone(&semantic);
+        // Poison the mutex the way a panicking analysis would.
+        let _ = std::thread::spawn(move || {
+            let _guard = poisoner.lock().expect("fresh mutex");
+            panic!("poison the semantic mutex");
+        })
+        .join();
+
+        let outcome: Result<(), McpError> = with_semantic(&semantic, "test", |_| Ok(())).await;
+        let error = outcome.expect_err("a poisoned mutex must surface as an error");
+        assert!(
+            error.message.contains("Failed to acquire lock"),
+            "unexpected error message: {}",
+            error.message
+        );
+    }
+
+    #[tokio::test]
+    async fn a_panicking_analysis_is_reported_rather_than_hanging() {
+        let outcome: Result<(), McpError> =
+            run_analysis("test", || panic!("boom in analysis")).await;
+        let error = outcome.expect_err("a panic must surface as an error");
+        assert!(
+            error.message.contains("panicked"),
+            "unexpected error message: {}",
+            error.message
+        );
+    }
+}

--- a/crates/rmc-server/src/lib.rs
+++ b/crates/rmc-server/src/lib.rs
@@ -13,4 +13,5 @@
 
 pub mod tools;
 pub mod mcp;
+mod deep_stack;
 pub mod semantic;

--- a/crates/rmc-server/src/tools/endpoints/analysis.rs
+++ b/crates/rmc-server/src/tools/endpoints/analysis.rs
@@ -91,6 +91,7 @@ use tracing;
 
 use rmc_engine::parser::RustParser;
 
+use crate::deep_stack::with_semantic;
 use crate::semantic::SemanticService;
 
 fn validate_cargo_project_directory(project_path: &Path) -> Result<(), McpError> {
@@ -130,11 +131,14 @@ pub(crate) async fn find_definition_with_semantic(
 
     tracing::debug!("Searching for definition of '{}' (exact={})", symbol_name, exact);
 
-    let locations = semantic
-        .lock()
-        .map_err(|e| McpError::internal_error(format!("Failed to acquire lock: {}", e), None))?
-        .symbol_search_with_exact(project_path, symbol_name, 50, exact)
-        .map_err(|e| McpError::internal_error(format!("Symbol search failed: {}", e), None))?;
+    let project_path = project_path.to_path_buf();
+    let symbol = symbol_name.to_string();
+    let locations = with_semantic(semantic, "find_definition", move |service| {
+        service
+            .symbol_search_with_exact(&project_path, &symbol, 50, exact)
+            .map_err(|e| McpError::internal_error(format!("Symbol search failed: {}", e), None))
+    })
+    .await?;
 
     if locations.is_empty() {
         Ok(CallToolResult::success(vec![Content::text(format!(
@@ -169,11 +173,14 @@ pub(crate) async fn find_references_with_semantic(
 
     tracing::debug!("Searching for references to '{}' (exact={})", symbol_name, exact);
 
-    let locations = semantic
-        .lock()
-        .map_err(|e| McpError::internal_error(format!("Failed to acquire lock: {}", e), None))?
-        .find_references_by_name_with_exact(project_path, symbol_name, exact)
-        .map_err(|e| McpError::internal_error(format!("Find references failed: {}", e), None))?;
+    let project_path = project_path.to_path_buf();
+    let symbol = symbol_name.to_string();
+    let locations = with_semantic(semantic, "find_references", move |service| {
+        service
+            .find_references_by_name_with_exact(&project_path, &symbol, exact)
+            .map_err(|e| McpError::internal_error(format!("Find references failed: {}", e), None))
+    })
+    .await?;
 
     if locations.is_empty() {
         Ok(CallToolResult::success(vec![Content::text(format!(
@@ -227,24 +234,34 @@ pub(crate) async fn rename_symbol_with_semantic(
                 project_path.join(input_path)
             };
 
-            semantic
-                .lock()
-                .map_err(|e| McpError::internal_error(format!("Failed to acquire lock: {}", e), None))?
-                .rename_by_position(
-                    project_path,
-                    &resolved_file_path,
-                    line,
-                    column,
-                    symbol_name,
-                    new_name,
-                )
-                .map_err(rename_mcp_error)?
+            let project_path = project_path.to_path_buf();
+            let symbol = symbol_name.to_string();
+            let new_name = new_name.to_string();
+            with_semantic(semantic, "rename_symbol", move |service| {
+                service
+                    .rename_by_position(
+                        &project_path,
+                        &resolved_file_path,
+                        line,
+                        column,
+                        &symbol,
+                        &new_name,
+                    )
+                    .map_err(rename_mcp_error)
+            })
+            .await?
         }
-        (None, None, None) => semantic
-            .lock()
-            .map_err(|e| McpError::internal_error(format!("Failed to acquire lock: {}", e), None))?
-            .rename_by_name(project_path, symbol_name, new_name)
-            .map_err(rename_mcp_error)?,
+        (None, None, None) => {
+            let project_path = project_path.to_path_buf();
+            let symbol = symbol_name.to_string();
+            let new_name = new_name.to_string();
+            with_semantic(semantic, "rename_symbol", move |service| {
+                service
+                    .rename_by_name(&project_path, &symbol, &new_name)
+                    .map_err(rename_mcp_error)
+            })
+            .await?
+        }
         _ => {
             return Err(McpError::invalid_params(
                 "file_path, line, and column must be provided together for position-based rename",

--- a/crates/rmc-server/src/tools/graph/audits.rs
+++ b/crates/rmc-server/src/tools/graph/audits.rs
@@ -4,8 +4,10 @@
 //! endpoint follows the shape documented in `graph_tools.rs`: parse MCP
 //! parameters, call graph-owned audit entry points, paginate, serialize.
 //!
-//! Graph audit facade calls are synchronous, so endpoint handlers wrap them in
-//! `spawn_blocking` before rendering MCP responses.
+//! Graph audit facade calls are synchronous and load a workspace through
+//! rust-analyzer, so endpoint handlers hand them to `deep_stack::run_analysis`
+//! before rendering MCP responses — the recursion inside them does not fit the
+//! stack a blocking-pool thread has.
 
 use std::path::PathBuf;
 
@@ -16,6 +18,7 @@ use rmc_graph::graph::{
     run_channel_capacity_audit, run_fn_body_audit, run_mut_static_audit, run_recursion_check,
     run_unsafe_audit,
 };
+use crate::deep_stack::run_analysis;
 use crate::tools::graph::response::*;
 
 use rmcp::{ErrorData as McpError, model::CallToolResult};
@@ -35,9 +38,8 @@ pub(crate) async fn unsafe_audit(
     params: crate::tools::params::UnsafeAuditParams,
 ) -> Result<CallToolResult, McpError> {
     let directory = PathBuf::from(&params.directory);
-    let findings = tokio::task::spawn_blocking(move || run_unsafe_audit(&directory))
-        .await
-        .map_err(|e| McpError::internal_error(format!("spawn_blocking join error: {e}"), None))?
+    let findings = run_analysis("unsafe_audit", move || run_unsafe_audit(&directory))
+        .await?
         .map_err(graph_audit_error("unsafe_audit"))?;
 
     #[derive(serde::Serialize)]
@@ -62,9 +64,8 @@ pub(crate) async fn mut_static_audit(
     params: crate::tools::params::MutStaticAuditParams,
 ) -> Result<CallToolResult, McpError> {
     let directory = PathBuf::from(&params.directory);
-    let findings = tokio::task::spawn_blocking(move || run_mut_static_audit(&directory))
-        .await
-        .map_err(|e| McpError::internal_error(format!("spawn_blocking join error: {e}"), None))?
+    let findings = run_analysis("mut_static_audit", move || run_mut_static_audit(&directory))
+        .await?
         .map_err(graph_audit_error("mut_static_audit"))?;
 
     #[derive(serde::Serialize)]
@@ -97,7 +98,7 @@ pub(crate) async fn recursion_check(
     let directory = PathBuf::from(&params.directory);
     let crate_name = params.crate_name.clone();
     let max_cycle_length = params.max_cycle_length;
-    let output = tokio::task::spawn_blocking(move || {
+    let output = run_analysis("recursion_check", move || {
         run_recursion_check(
             &directory,
             RecursionCheckOptions {
@@ -106,8 +107,7 @@ pub(crate) async fn recursion_check(
             },
         )
     })
-    .await
-    .map_err(|e| McpError::internal_error(format!("spawn_blocking join error: {e}"), None))?
+    .await?
     .map_err(graph_audit_error("recursion_check"))?;
 
     #[derive(serde::Serialize)]
@@ -147,7 +147,7 @@ pub(crate) async fn channel_capacity_audit(
     let crate_name = params.crate_name.clone();
     let skip_test_fns = params.skip_test_fns.unwrap_or(true);
 
-    let findings = tokio::task::spawn_blocking(move || {
+    let findings = run_analysis("channel_capacity_audit", move || {
         run_channel_capacity_audit(
             &directory,
             ChannelCapacityAuditOptions {
@@ -156,9 +156,8 @@ pub(crate) async fn channel_capacity_audit(
             },
         )
     })
-        .await
-        .map_err(|e| McpError::internal_error(format!("spawn_blocking join error: {e}"), None))?
-        .map_err(graph_audit_error("channel_capacity_audit"))?;
+    .await?
+    .map_err(graph_audit_error("channel_capacity_audit"))?;
 
     #[derive(serde::Serialize)]
     struct ScopeSummary {
@@ -197,7 +196,7 @@ pub(crate) async fn fn_body_audit(
     let patterns = params.patterns.clone();
     let skip_test_fns = params.skip_test_fns.unwrap_or(true);
 
-    let output = tokio::task::spawn_blocking(move || {
+    let output = run_analysis("fn_body_audit", move || {
         run_fn_body_audit(
             &directory,
             FnBodyAuditOptions {
@@ -207,9 +206,8 @@ pub(crate) async fn fn_body_audit(
             },
         )
     })
-        .await
-        .map_err(|e| McpError::internal_error(format!("spawn_blocking join error: {e}"), None))?
-        .map_err(graph_audit_error("fn_body_audit"))?;
+    .await?
+    .map_err(graph_audit_error("fn_body_audit"))?;
 
     #[derive(serde::Serialize)]
     struct ScopeSummary {

--- a/crates/rmc-server/src/tools/graph/core.rs
+++ b/crates/rmc-server/src/tools/graph/core.rs
@@ -15,6 +15,7 @@ use rmc_graph::graph::{
     ModuleDependencySymbol, ModuleTreeNode, NodeKind, RecursiveCallersCount, UsageSummaryRow,
     WorkspaceStats, build_and_persist,
 };
+use crate::deep_stack::run_analysis;
 use crate::tools::graph::response::*;
 use crate::tools::params::{
     BuildHypergraphParams, CallGraphParams, CallersInCrateParams, CallsFromParams,
@@ -40,11 +41,12 @@ pub(crate) async fn build_hypergraph(
         ..Default::default()
     };
     // build_and_persist runs `loader::load` + the full extract pass + LMDB
-    // writes synchronously (4-18s wall-clock). Hand off to a blocking thread
-    // so the tokio runtime worker stays free to handle other tool calls.
-    let result = tokio::task::spawn_blocking(move || build_and_persist(&dir, opts))
-        .await
-        .map_err(|e| McpError::internal_error(format!("spawn_blocking join error: {e}"), None))?
+    // writes synchronously (4-18s wall-clock), so it must leave the runtime
+    // worker. It goes to an analysis thread rather than the blocking pool
+    // because the extract pass recurses over HIR: this is the call that
+    // overflowed a 2 MiB pool stack and aborted the server.
+    let result = run_analysis("build_hypergraph", move || build_and_persist(&dir, opts))
+        .await?
         .map_err(|e| McpError::internal_error(format!("build_hypergraph failed: {e:#}"), None))?;
 
     json_result(&BuildHypergraphResponse {

--- a/crates/rmc-server/src/tools/graph/skeleton.rs
+++ b/crates/rmc-server/src/tools/graph/skeleton.rs
@@ -12,6 +12,7 @@ use serde::Serialize;
 use rmc_graph::graph::{
     SkeletonFile, SkeletonOptions, render_crate_skeletons,
 };
+use crate::deep_stack::run_analysis;
 use crate::tools::graph::response::*;
 use crate::tools::params::CrateSkeletonParams;
 
@@ -39,7 +40,7 @@ pub(crate) async fn crate_skeleton(
     let page_req = list_page(&params.pagination);
     let opts = graph_options(&params);
 
-    let response = tokio::task::spawn_blocking(move || {
+    let response = run_analysis("crate_skeleton", move || {
         let snap = open_workspace_snapshot(&directory)?;
         if clean && skeleton_dir.exists() {
             fs::remove_dir_all(&skeleton_dir).map_err(|e| {
@@ -113,8 +114,7 @@ pub(crate) async fn crate_skeleton(
                 .collect(),
         })
     })
-    .await
-    .map_err(|e| McpError::internal_error(format!("spawn_blocking join error: {e}"), None))??;
+    .await??;
 
     json_result(&response)
 }


### PR DESCRIPTION
## The problem

Work that loads a workspace through rust-analyzer walks HIR/AST trees recursively — `build_hypergraph`, the five audits, `crate_skeleton`, and every semantic query alike. That recursion is bounded by the shape of the analyzed source, not by anything this repository controls, and it does not fit in the 2 MiB stack a tokio blocking-pool thread gets by default:

```text
thread 'tokio-rt-worker' has overflowed its stack
fatal runtime error: stack overflow, aborting
```

A stack overflow is an `abort`, not a `panic`. It takes the whole server down rather than failing one tool call, so no caller can guard against it — and with the daemon from #12 now on `main`, one oversized workspace ends every session attached to that server, not just the one that asked.

## What it does

- `deep_stack::run_analysis` spawns a named thread with a 64 MiB stack and awaits the result. A straight swap for `spawn_blocking`, whose only shortcoming here is that the pool's stack size cannot be set per task.
- `deep_stack::with_semantic` becomes the single door to the `SemanticService` from async code. Taking the mutex inline in an `async fn` does two wrong things at once — rust-analyzer runs on the worker's 2 MiB stack **and** the runtime is blocked for the duration — and both are easy to reintroduce by accident when the lock is one method call away.
- Call sites moved over: `build_hypergraph`, `crate_skeleton`, `unsafe_audit`, `mut_static_audit`, `recursion_check`, `channel_capacity_audit`, `fn_body_audit`, `find_definition`, `find_references`, `rename_symbol`.

## The size is measured, not guessed

2 MiB aborts on this workspace, 32 MiB completes it. 64 MiB doubles that headroom and costs only address space: thread stacks are mapped lazily, so pages a shallower walk never touches are never backed by memory.

## Oracles

`cargo test -p rmc-server --lib deep_stack` — 6 passed:

- a recursion of ~1000 frames × 8 KiB completes through `run_analysis`, and again through `with_semantic`. These are positive controls for the stack size itself: if `stack_size` ever stops being applied, they abort rather than fail quietly.
- semantic work reports the thread name `rmc-analysis`, which is how "someone took the lock inline again" becomes observable rather than merely slower.
- a panicking analysis surfaces as an error rather than hanging; a poisoned mutex is reported rather than propagated.

## Scope

This is the first of a series splitting the remainder of #12 by subject, now that the transport itself is on `main`. The memory watchdog, the retirement path, the working-set cap and the stale-context refresh each follow separately, so they can be judged one at a time.
